### PR TITLE
Feat/onboarding flow

### DIFF
--- a/be/config/environment.py
+++ b/be/config/environment.py
@@ -5,6 +5,7 @@ class Settings(BaseSettings):
     root_domain: str = "https://spit.sh/"
     database_url: str = "sqlite+aiosqlite:///./test_db.db"
     better_auth_secret: str = ""
+    better_auth_url: str = "http://localhost:3000"
 
     class Config:
         env_file = ".env"

--- a/be/crud/link.py
+++ b/be/crud/link.py
@@ -1,7 +1,8 @@
+from uuid import UUID
 from sqlalchemy.future import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from schemas.linkSchema import LinkCreate, LinkData
+from schemas.linkSchema import LinkCreate, LinkData, LinkInfo
 from models.base import Link
 
 
@@ -21,3 +22,20 @@ async def create_link(
     await db.commit()
     await db.refresh(link)
     return LinkData(url=link.url, slug=link.slug, shortenUrl=link.shortenUrl)
+
+
+async def create_link_with_user(
+    linkData: LinkCreate, short_link: str, project_id: UUID, db: AsyncSession
+) -> LinkInfo:
+    link = Link(
+        url=linkData.url,
+        slug=linkData.slug,
+        shortenUrl=short_link,
+        project_id=project_id,
+    )
+    db.add(link)
+    await db.commit()
+    await db.refresh(link)
+    return LinkInfo(
+        id=link.id, url=link.url, slug=link.slug, shortenUrl=link.shortenUrl, clicks=[]
+    )

--- a/be/crud/project.py
+++ b/be/crud/project.py
@@ -1,11 +1,12 @@
 import uuid
-from typing import List
+from typing import List, Tuple
 from sqlalchemy.future import select
+from sqlalchemy import func
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.exc import IntegrityError
 from fastapi import HTTPException
 
-from models.base import Project, ProjectUsers, ProjectRole
+from models.base import Project, ProjectUsers, ProjectRole, Link
 from schemas.projectSchema import ProjectCreate
 
 
@@ -32,10 +33,15 @@ async def create_project(
     return project
 
 
-async def get_user_projects(user_id: uuid.UUID, db: AsyncSession) -> List[Project]:
-    result = await db.execute(
-        select(Project)
+async def get_user_projects(
+    user_id: uuid.UUID, db: AsyncSession
+) -> List[Tuple[Project, int]]:
+    stmt = (
+        select(Project, func.count(Link.id).label("links_count"))
         .join(ProjectUsers, ProjectUsers.project_id == Project.id)
+        .outerjoin(Link, Link.project_id == Project.id)
         .where(ProjectUsers.user_id == user_id)
+        .group_by(Project.id)
     )
-    return result.scalars().all()
+    result = await db.execute(stmt)
+    return result.all()

--- a/be/crud/project.py
+++ b/be/crud/project.py
@@ -1,0 +1,41 @@
+import uuid
+from typing import List
+from sqlalchemy.future import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.exc import IntegrityError
+from fastapi import HTTPException
+
+from models.base import Project, ProjectUsers, ProjectRole
+from schemas.projectSchema import ProjectCreate
+
+
+async def create_project(
+    data: ProjectCreate,
+    user_id: uuid.UUID,
+    db: AsyncSession,
+) -> Project:
+    project = Project(name=data.name, slug=data.slug, logo=data.logo)
+    db.add(project)
+    try:
+        await db.flush()
+    except IntegrityError:
+        await db.rollback()
+        raise HTTPException(status_code=409, detail="Slug already taken")
+    membership = ProjectUsers(
+        project_id=project.id,
+        user_id=user_id,
+        role=ProjectRole.Onwer,
+    )
+    db.add(membership)
+    await db.commit()
+    await db.refresh(project)
+    return project
+
+
+async def get_user_projects(user_id: uuid.UUID, db: AsyncSession) -> List[Project]:
+    result = await db.execute(
+        select(Project)
+        .join(ProjectUsers, ProjectUsers.project_id == Project.id)
+        .where(ProjectUsers.user_id == user_id)
+    )
+    return result.scalars().all()

--- a/be/crud/user.py
+++ b/be/crud/user.py
@@ -1,7 +1,9 @@
 import uuid
+from typing import Optional
 from sqlalchemy.future import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from models.base import User
+from schemas.userSchema import UpdateProfileRequest
 
 
 async def find_user_by_id(id: uuid.UUID, db: AsyncSession) -> User | None:
@@ -26,6 +28,24 @@ async def create_user(email: str, db: AsyncSession) -> User:
 async def update_user(user_id: uuid.UUID, email: str, db: AsyncSession) -> User:
     user = await db.get(User, user_id)
     user.email = email
+    await db.commit()
+    await db.refresh(user)
+    return user
+
+
+async def update_user_profile(
+    user_id: uuid.UUID,
+    data: UpdateProfileRequest,
+    db: AsyncSession,
+) -> Optional[User]:
+    result = await db.execute(select(User).where(User.id == user_id))
+    user = result.scalars().one_or_none()
+    if not user:
+        return None
+    user.first_name = data.first_name
+    user.last_name = data.last_name
+    if data.image is not None:
+        user.image = data.image
     await db.commit()
     await db.refresh(user)
     return user

--- a/be/main.py
+++ b/be/main.py
@@ -4,7 +4,7 @@ from slowapi import _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
 from utils.limiter import limiter
 
-from routers import linkRouter
+from routers import linkRouter, userRouter, projectRouter
 
 from typing import List
 
@@ -21,7 +21,7 @@ def configure_routes(routers: List[APIRouter], prefix: str = "/api/v1"):
         app.include_router(router, prefix=prefix)
 
 
-configure_routes([linkRouter.router])
+configure_routes([linkRouter.router, userRouter.router, projectRouter.router])
 
 origins = [
     "*",

--- a/be/models/base.py
+++ b/be/models/base.py
@@ -29,6 +29,7 @@ class User(SQLModel, table=True):
 
     first_name: Optional[str] = Field(nullable=True, max_length=20)
     last_name: Optional[str] = Field(nullable=True, max_length=25)
+    image: Optional[str] = Field(default=None, nullable=True)
 
     #     # Relationships
     projects: List["Project"] = Relationship(

--- a/be/routers/projectRouter.py
+++ b/be/routers/projectRouter.py
@@ -27,4 +27,8 @@ async def list_projects(
     session: AsyncSession = Depends(get_session),
 ):
     user_id = uuid.UUID(current_user["sub"])
-    return await get_user_projects(user_id, session)
+    rows = await get_user_projects(user_id, session)
+    return [
+        ProjectResponse(**row[0].dict(), links_count=row[1])
+        for row in rows
+    ]

--- a/be/routers/projectRouter.py
+++ b/be/routers/projectRouter.py
@@ -1,0 +1,30 @@
+import uuid
+from typing import List
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from database import get_session
+from utils.jwt_auth import get_current_user
+from crud.project import create_project, get_user_projects
+from schemas.projectSchema import ProjectCreate, ProjectResponse
+
+router = APIRouter(prefix="/projects", tags=["projects"])
+
+
+@router.post("/", response_model=ProjectResponse, status_code=201)
+async def create_new_project(
+    payload: ProjectCreate,
+    current_user: dict = Depends(get_current_user),
+    session: AsyncSession = Depends(get_session),
+):
+    user_id = uuid.UUID(current_user["sub"])
+    return await create_project(payload, user_id, session)
+
+
+@router.get("/", response_model=List[ProjectResponse])
+async def list_projects(
+    current_user: dict = Depends(get_current_user),
+    session: AsyncSession = Depends(get_session),
+):
+    user_id = uuid.UUID(current_user["sub"])
+    return await get_user_projects(user_id, session)

--- a/be/routers/userRouter.py
+++ b/be/routers/userRouter.py
@@ -1,0 +1,35 @@
+import uuid
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from database import get_session
+from utils.jwt_auth import get_current_user
+from crud.user import find_user_by_id, update_user_profile
+from schemas.userSchema import UpdateProfileRequest, UserProfileResponse
+
+router = APIRouter(prefix="/users", tags=["users"])
+
+
+@router.get("/me", response_model=UserProfileResponse)
+async def get_profile(
+    current_user: dict = Depends(get_current_user),
+    session: AsyncSession = Depends(get_session),
+):
+    user_id = uuid.UUID(current_user["sub"])
+    user = await find_user_by_id(user_id, session)
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+    return user
+
+
+@router.patch("/me", response_model=UserProfileResponse)
+async def patch_profile(
+    payload: UpdateProfileRequest,
+    current_user: dict = Depends(get_current_user),
+    session: AsyncSession = Depends(get_session),
+):
+    user_id = uuid.UUID(current_user["sub"])
+    user = await update_user_profile(user_id, payload, session)
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+    return user

--- a/be/schemas/linkSchema.py
+++ b/be/schemas/linkSchema.py
@@ -1,5 +1,9 @@
+from uuid import UUID
+
 from sqlmodel import SQLModel
 from pydantic import BaseModel
+from tomlkit import datetime
+
 
 class LinkBase(BaseModel):
     url: str
@@ -16,6 +20,14 @@ class LinkData(LinkBase):
 
 class LinkInfo(LinkData):
     clicks: int
+
+
+class LinkResponse(LinkInfo):
+    id: UUID
+
+    project_id: UUID | None
+    created_at: datetime
+    last_edited: datetime
 
 
 class ClickBase(SQLModel):

--- a/be/schemas/linkSchema.py
+++ b/be/schemas/linkSchema.py
@@ -2,7 +2,6 @@ from uuid import UUID
 
 from sqlmodel import SQLModel
 from pydantic import BaseModel
-from tomlkit import datetime
 
 
 class LinkBase(BaseModel):
@@ -20,14 +19,6 @@ class LinkData(LinkBase):
 
 class LinkInfo(LinkData):
     clicks: int
-
-
-class LinkResponse(LinkInfo):
-    id: UUID
-
-    project_id: UUID | None
-    created_at: datetime
-    last_edited: datetime
 
 
 class ClickBase(SQLModel):

--- a/be/schemas/projectSchema.py
+++ b/be/schemas/projectSchema.py
@@ -16,3 +16,4 @@ class ProjectResponse(BaseModel):
     slug: str
     logo: Optional[str]
     created_at: datetime
+    links_count: int = 0

--- a/be/schemas/projectSchema.py
+++ b/be/schemas/projectSchema.py
@@ -1,0 +1,18 @@
+from pydantic import BaseModel, Field
+from typing import Optional
+from datetime import datetime
+import uuid
+
+
+class ProjectCreate(BaseModel):
+    name: str = Field(..., max_length=20)
+    slug: str = Field(..., max_length=30, regex=r"^[a-z0-9-]+$")
+    logo: Optional[str] = None
+
+
+class ProjectResponse(BaseModel):
+    id: uuid.UUID
+    name: str
+    slug: str
+    logo: Optional[str]
+    created_at: datetime

--- a/be/schemas/userSchema.py
+++ b/be/schemas/userSchema.py
@@ -1,6 +1,7 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 import uuid
 from datetime import datetime
+from typing import Optional
 
 
 class UserBase(BaseModel):
@@ -15,4 +16,20 @@ class UserDetials(UserCreate):
     id: uuid.UUID
     first_name: str | None
     last_name: str | None
+    joined_at: datetime
+
+
+class UpdateProfileRequest(BaseModel):
+    first_name: str = Field(..., max_length=20)
+    last_name: str = Field(..., max_length=25)
+    image: Optional[str] = None
+
+
+class UserProfileResponse(BaseModel):
+    id: uuid.UUID
+    email: str
+    username: Optional[str]
+    first_name: Optional[str]
+    last_name: Optional[str]
+    image: Optional[str]
     joined_at: datetime

--- a/be/utils/jwt_auth.py
+++ b/be/utils/jwt_auth.py
@@ -11,7 +11,6 @@ async def get_current_user(
     credentials: HTTPAuthorizationCredentials = Depends(bearer_scheme),
 ) -> dict:
     token = credentials.credentials
-    print("Received token:", token)  # Debugging statement
     try:
         payload = jwt.decode(
             token,

--- a/be/utils/jwt_auth.py
+++ b/be/utils/jwt_auth.py
@@ -11,6 +11,7 @@ async def get_current_user(
     credentials: HTTPAuthorizationCredentials = Depends(bearer_scheme),
 ) -> dict:
     token = credentials.credentials
+    print("Received token:", token)  # Debugging statement
     try:
         payload = jwt.decode(
             token,

--- a/docs/prd/shared/onboarding-prd.md
+++ b/docs/prd/shared/onboarding-prd.md
@@ -1,629 +1,157 @@
-# Onboarding Flow — PRD
+# Onboarding & Dashboard Flow — PRD
 
 ## Overview
 
-When a user registers for the first time (via email OTP or OAuth), they are redirected through a 2-step onboarding flow before reaching the dashboard. The flow collects their personal profile details and creates their first project, ensuring they have a named workspace ready to use.
+After a user signs in (via email OTP or OAuth), they are always redirected to `/dashboard`. The dashboard home page fetches their projects server-side and applies the following routing logic:
 
-**Trigger condition:** User is authenticated but `first_name` is `null`.
+- **0 projects** → redirect to `/onboarding`
+- **1 project** → redirect directly to `/dashboard/<slug>` (their workspace)
+- **2+ projects** → display workspace selection cards
 
----
-
-## User Flow
-
-```
-Sign up / First login
-        ↓
-/onboarding  →  Step 1: Personal Details  →  Step 2: New Project  →  /dashboard
-```
-
-Returning users with `first_name` set who navigate to `/onboarding` are redirected to `/dashboard`.
+The onboarding flow collects profile info (step 1) and creates the user's first project (step 2), then redirects to project workspace created `/dashboard/<slug>`.
 
 ---
 
-## Design
+## User Flows
+
+### New user (first login)
+```
+Sign in → /dashboard → 0 projects → /onboarding → Step 1 → Step 2 → /dashboard → /dashboard/<slug>
+```
+
+### Returning user with one project
+```
+Sign in → /dashboard → 1 project → /dashboard/<slug>
+```
+
+### Returning user with multiple projects
+```
+Sign in → /dashboard → show workspace cards → click card → /dashboard/<slug>
+```
+
+---
+
+## Dashboard Home — `/dashboard`
+
+Server Component. Fetches `GET /api/v1/projects/` using the `spit_session` JWT cookie.
+
+### Redirect logic
+```
+projects.length === 0  →  redirect("/onboarding")
+projects.length === 1  →  redirect(`/dashboard/${projects[0].slug}`)
+projects.length >= 2   →  render workspace card grid
+```
+
+### Workspace card grid
+- Responsive grid: 1 col mobile, 2 col sm, 3 col lg
+- Each card: dark bordered box, project name (bold), link count ("X active links")
+- Click navigates to `/dashboard/<slug>`
+- Hover: fuchsia border accent
+
+---
+
+## Dashboard Header — `DashboardLayout`
+
+Replaces the sidebar with a top-bar layout.
 
 ### Layout
-- Full-height page with a subtle dark gradient background (`from-zinc-950 to-zinc-900`)
-- Single centered card (`max-w-md`, white/zinc-900 dark, rounded-2xl, shadow-xl)
-- Step progress indicator: 2 dots at the top of the card (fuchsia active, zinc inactive)
-- Logo/wordmark at the very top of the page (above the card)
+- Full-width top bar with `border-b border-zinc-800`
+- **Left:** `Spit.sh` logo (link to `/dashboard`)
+- **Right:** User avatar circle + name/email → click toggles dropdown
+- Dropdown contains a single "Log out" button
+- Content area below the header
 
-### Brand & Style
-- **Primary accent:** `fuchsia-600`
-- **Primary button:** `bg-fuchsia-600 text-white px-8 py-3 rounded-full font-semibold hover:bg-fuchsia-700 focus:ring focus:outline-none focus:ring-offset-2 focus:ring-fuchsia-200 transition-all`
-- **Ghost/back button:** `text-zinc-400 hover:text-zinc-200 transition-colors`
-- **Input fields:** `w-full rounded-xl border border-zinc-200 dark:border-zinc-700 bg-transparent px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-fuchsia-500`
-- **Icons:** Phosphor Icons (`@phosphor-icons/react`) — `weight="duotone"` for hero icons, `weight="regular"` for inline
+---
+
+## Onboarding Flow — `/onboarding`
+
+### Trigger
+Redirected here from `/dashboard` when user has 0 projects.
+
+### Guard (on mount)
+`getProjectsAction()` → if projects exist, `router.replace("/dashboard")`
 
 ---
 
 ## Step 1 — Personal Details
 
-### UI
-- **Hero icon:** `<UserCircle size={56} weight="duotone" className="text-fuchsia-500" />`
-- **Heading:** "Welcome to Spit.sh"
-- **Subheading:** "Let's set up your profile first."
-- **Fields:**
-  - First Name (required)
-  - Last Name (required)
-- **CTA:** "Continue" with `<ArrowRight />` icon (fuchsia primary button, full width)
-
-### Validation (Yup)
-```
-first_name: string, required, max 20 chars
-last_name:  string, required, max 25 chars
-```
-
-### On Submit
-- `PATCH /api/v1/users/me` with `{ first_name, last_name }`
-- On success → advance to Step 2
+- Icon: `<UserCircle size={56} weight="duotone" className="text-fuchsia-500" />`
+- Fields: First Name, Last Name (both required)
+- `PATCH /api/v1/users/me` on submit → advance to Step 2
 
 ---
 
 ## Step 2 — New Project
 
-### UI
-- **Hero icon:** `<Folder size={56} weight="duotone" className="text-fuchsia-500" />`
-- **Heading:** "Create your first project"
-- **Subheading:** "Projects help you organise and share links."
-- **Fields:**
-  - Project Name (required, max 20 chars)
-  - Slug — auto-derived from name (slugified), editable; shows `<PencilSimple />` icon button to unlock editing; prefix label shows `spit.sh/`
-  - Logo URL (optional) — text input with `<ImageSquare />` icon; if a valid URL is entered, show a small circular preview beside the field
-- **Buttons:**
-  - "Create Project" with `<ArrowRight />` (fuchsia primary, full width)
-  - "Back" text link above or below (ghost, navigates back to Step 1)
+- Icon: `<Folder size={56} weight="duotone" className="text-fuchsia-500" />`
+- Fields: Project Name, Slug (auto-derived, lockable), Logo URL (optional)
+- `POST /api/v1/projects/` on submit → redirect to `/dashboard`
 
-### Slug Auto-generation Rule
-Derived from project name: lowercase, spaces → hyphens, strip non-alphanumeric (except hyphens), max 30 chars. Regenerated live as the user types the name unless the user has manually edited the slug field.
+---
 
-### Validation (Yup)
-```
-name: string, required, max 20 chars
-slug: string, required, max 30 chars, matches /^[a-z0-9-]+$/
-logo: string, optional, valid URL when present
-```
+## Auth Cookie
 
-### On Submit
-- `POST /api/v1/projects/` with `{ name, slug, logo? }`
-- On success → redirect to `/dashboard`
+On successful OTP verification (`verify/page.tsx`):
+1. `setUserCookie(data.user.id)` — signs a HS256 JWT `{ sub: userId }` with `BETTER_AUTH_SECRET`, stored as HTTP-only cookie `spit_session` (30-day expiry)
+2. `router.push("/dashboard")`
+
+On logout: `deleteUserCookie()` + `signOut()` → redirect to `/signin`
+
+---
+
+## Server Actions (`frontend/app/actions/`)
+
+| File | Exports |
+|------|---------|
+| `auth.ts` | `setUserCookie(userId)`, `deleteUserCookie()`, `getSessionToken()` |
+| `project.ts` | `getProjectsAction()`, `createProjectAction(data)` |
+| `user.ts` | `updateProfileAction(data)` |
+
+Server Actions read the `spit_session` cookie via `getSessionToken()` and forward the JWT as `Authorization: Bearer <token>` to FastAPI.
 
 ---
 
 ## Backend
 
-### 1. Model Change — `be/models/base.py`
-
-Add `image` field to `User`:
+### `ProjectResponse` schema
 
 ```python
-image: Optional[str] = Field(default=None, nullable=True)
-```
-
-> No Alembic migration needed — dev uses SQLite with auto `create_all`.
-
----
-
-### 2. Schemas
-
-#### `be/schemas/userSchema.py` — additions
-
-```python
-class UpdateProfileRequest(BaseModel):
-    first_name: str = Field(..., max_length=20)
-    last_name: str = Field(..., max_length=25)
-    image: Optional[str] = None
-
-class UserProfileResponse(BaseModel):
-    id: uuid.UUID
-    email: str
-    username: Optional[str]
-    first_name: Optional[str]
-    last_name: Optional[str]
-    image: Optional[str]
-    joined_at: datetime
-```
-
-#### `be/schemas/projectSchema.py` — new file
-
-```python
-from pydantic import BaseModel, Field
-from typing import Optional
-from datetime import datetime
-import uuid
-
-class ProjectCreate(BaseModel):
-    name: str = Field(..., max_length=20)
-    slug: str = Field(..., max_length=30, regex=r"^[a-z0-9-]+$")
-    logo: Optional[str] = None
-
 class ProjectResponse(BaseModel):
     id: uuid.UUID
     name: str
     slug: str
     logo: Optional[str]
     created_at: datetime
+    links_count: int = 0
 ```
 
----
+### `GET /projects/` CRUD
 
-### 3. CRUD
-
-#### `be/crud/user.py` — add `update_user_profile`
-
-Returns `None` if the user doesn't exist — the router raises the 404. Keeps the CRUD layer free of HTTP concerns.
-
-```python
-async def update_user_profile(
-    user_id: uuid.UUID,
-    data: UpdateProfileRequest,
-    db: AsyncSession,
-) -> Optional[User]:
-    result = await db.execute(select(User).where(User.id == user_id))
-    user = result.scalars().one_or_none()
-    if not user:
-        return None
-    user.first_name = data.first_name
-    user.last_name = data.last_name
-    if data.image is not None:
-        user.image = data.image
-    await db.commit()
-    await db.refresh(user)
-    return user
-```
-
-#### `be/crud/project.py` — new file
-
-Catches `IntegrityError` (slug conflict) and re-raises as `HTTPException(409)`. All other DB errors propagate naturally.
-
-```python
-from sqlalchemy.exc import IntegrityError
-from fastapi import HTTPException
-
-async def create_project(
-    data: ProjectCreate,
-    user_id: uuid.UUID,
-    db: AsyncSession,
-) -> Project:
-    project = Project(name=data.name, slug=data.slug, logo=data.logo)
-    db.add(project)
-    try:
-        await db.flush()
-    except IntegrityError:
-        await db.rollback()
-        raise HTTPException(status_code=409, detail="Slug already taken")
-    membership = ProjectUsers(
-        project_id=project.id,
-        user_id=user_id,
-        role=ProjectRole.Onwer,
-    )
-    db.add(membership)
-    await db.commit()
-    await db.refresh(project)
-    return project
-```
-
-> Note: `IntegrityError` from a slug conflict is a data-level concern so it's acceptable to raise `HTTPException` here. The router stays thin.
-
----
-
-### 4. Routers
-
-#### `be/routers/userRouter.py` — new file
-
-```
-GET   /users/me    → get current user profile
-PATCH /users/me    → update profile (first_name, last_name, image)
-```
-
-Both endpoints require auth (`Depends(get_current_user)` from `utils/jwt_auth.py`). Extract `user_id` from JWT payload `sub` field.
-
-Response model: `UserProfileResponse`.
-
-#### `be/routers/projectRouter.py` — new file
-
-```
-POST /projects/    → create project + owner membership
-GET  /projects/    → list projects for current user
-```
-
-Both require auth. `POST` returns `ProjectResponse`. `GET` returns `List[ProjectResponse]`.
-
-For `GET /projects/`: query `ProjectUsers` joined to `Project` where `user_id = current_user_id`.
-
----
-
-### 5. Register Routers — `be/main.py`
-
-```python
-from routers import linkRouter, userRouter, projectRouter
-
-configure_routes([linkRouter.router, userRouter.router, projectRouter.router])
-```
-
----
-
-## Frontend
-
-### New Files
-
-| Path | Purpose |
-|------|---------|
-| `frontend/app/onboarding/page.tsx` | Page container, manages `step` state (1 \| 2) |
-| `frontend/components/onboarding/PersonalDetailsStep.tsx` | Step 1 form |
-| `frontend/components/onboarding/NewProjectStep.tsx` | Step 2 form |
-| `frontend/lib/queries/user.ts` | `updateProfile()`, `getProfile()` API calls |
-| `frontend/lib/queries/project.ts` | `createProject()`, `getProjects()` API calls |
-| `frontend/hooks/useOnboarding.ts` | Step state + submission logic |
-| `frontend/hooks/useToast.ts` | Thin wrapper around sonner for typed toast notifications |
-
----
-
-### Toast System
-
-**Install:** `pnpm dlx shadcn@latest add sonner`
-
-**`<Toaster />`** must be mounted once in the root layout (`frontend/app/layout.tsx`):
-
-```tsx
-import { Toaster } from "@/components/ui/sonner";
-
-// inside <body>:
-<Toaster position="bottom-right" richColors />
-```
-
----
-
-#### Hook — `frontend/hooks/useToast.ts`
-
-```typescript
-import { toast } from "sonner";
-
-type ToastState = "success" | "warning" | "error" | "neutral";
-
-export function useToast() {
-  const showToast = (message: string, state: ToastState = "neutral") => {
-    switch (state) {
-      case "success":
-        toast.success(message);
-        break;
-      case "warning":
-        toast.warning(message);
-        break;
-      case "error":
-        toast.error(message);
-        break;
-      case "neutral":
-      default:
-        toast(message);
-    }
-  };
-
-  return { showToast };
-}
-```
-
-**Usage anywhere in the app:**
-```typescript
-const { showToast } = useToast();
-
-showToast("Profile saved.", "success");
-showToast("Slug already taken.", "error");
-showToast("Redirecting you to the dashboard…", "neutral");
-```
-
-**Toast states mapped to sonner:**
-
-| State | Sonner call | Visual (richColors) |
-|-------|-------------|---------------------|
-| `success` | `toast.success()` | Green icon + border |
-| `warning` | `toast.warning()` | Amber icon + border |
-| `error` | `toast.error()` | Red icon + border |
-| `neutral` | `toast()` | Default zinc styling |
-
----
-
-### API Queries
-
-#### `frontend/lib/queries/user.ts`
-
-```typescript
-import axios from "axios";
-import { API_URL } from "@/lib/config/public_env";
-
-export const updateProfile = async (
-  data: { first_name: string; last_name: string; image?: string },
-  token: string
-) => {
-  const res = await axios.patch(`${API_URL}/users/me`, data, {
-    headers: { Authorization: `Bearer ${token}` },
-  });
-  return res.data;
-};
-
-export const getProfile = async (token: string) => {
-  const res = await axios.get(`${API_URL}/users/me`, {
-    headers: { Authorization: `Bearer ${token}` },
-  });
-  return res.data;
-};
-```
-
-#### `frontend/lib/queries/project.ts`
-
-```typescript
-import axios from "axios";
-import { API_URL } from "@/lib/config/public_env";
-
-export const createProject = async (
-  data: { name: string; slug: string; logo?: string },
-  token: string
-) => {
-  const res = await axios.post(`${API_URL}/projects/`, data, {
-    headers: { Authorization: `Bearer ${token}` },
-  });
-  return res.data;
-};
-```
-
----
-
-### Hook — `frontend/hooks/useOnboarding.ts`
-
-```typescript
-"use client";
-import { useState } from "react";
-import { useRouter } from "next/navigation";
-import { updateProfile } from "@/lib/queries/user";
-import { createProject } from "@/lib/queries/project";
-
-export function useOnboarding(token: string) {
-  const [step, setStep] = useState<1 | 2>(1);
-  const router = useRouter();
-
-  const submitProfile = async (values: { first_name: string; last_name: string }) => {
-    await updateProfile(values, token);
-    setStep(2);
-  };
-
-  const submitProject = async (values: { name: string; slug: string; logo?: string }) => {
-    await createProject(values, token);
-    router.push("/dashboard");
-  };
-
-  return { step, setStep, isLoading, submitProfile, submitProject };
-}
-```
-
----
-
-### Middleware Update — `frontend/middleware.ts`
-
-Add `/onboarding` to the list of protected routes (requires session). Then add redirect logic after the existing session check:
-
-```typescript
-// Unauthenticated users hitting /onboarding → /signin (handled by existing protected route guard)
-
-// Authenticated users without first_name → redirect /dashboard to /onboarding
-if (req.nextUrl.pathname.startsWith("/dashboard") && !session.user.firstName) {
-  return NextResponse.redirect(new URL("/onboarding", req.url));
-}
-
-// Authenticated users who completed onboarding → redirect /onboarding to /dashboard
-if (req.nextUrl.pathname.startsWith("/onboarding") && session.user.firstName) {
-  return NextResponse.redirect(new URL("/dashboard", req.url));
-}
-```
-
-> `session.user.firstName` requires `better-auth` to expose the field. If it isn't available in the session object by default, handle the redirect inside `onboarding/page.tsx` on mount: call `getProfile(token)` and `router.replace("/dashboard")` if `first_name` is already set.
-
----
-
-### Onboarding Page — `frontend/app/onboarding/page.tsx`
-
-```tsx
-"use client";
-import { useSession } from "@/lib/auth-client";
-import { useOnboarding } from "@/hooks/useOnboarding";
-import PersonalDetailsStep from "@/components/onboarding/PersonalDetailsStep";
-import NewProjectStep from "@/components/onboarding/NewProjectStep";
-
-export default function OnboardingPage() {
-  const { data: session } = useSession();
-  const token = session?.session?.token ?? "";
-  const { step, setStep, submitProfile, submitProject } = useOnboarding(token);
-
-  return (
-    <main className="min-h-screen bg-gradient-to-br from-zinc-950 to-zinc-900 flex flex-col items-center justify-center px-4">
-      {/* Logo */}
-      <div className="mb-8 text-2xl font-bold text-white tracking-tight">
-        spit<span className="text-fuchsia-500">.sh</span>
-      </div>
-
-      {/* Card */}
-      <div className="w-full max-w-md bg-zinc-900 border border-zinc-800 rounded-2xl shadow-2xl p-8">
-        {/* Step dots */}
-        <div className="flex gap-2 justify-center mb-8">
-          <span className={`h-2 w-6 rounded-full transition-all ${step === 1 ? "bg-fuchsia-500" : "bg-zinc-700"}`} />
-          <span className={`h-2 w-6 rounded-full transition-all ${step === 2 ? "bg-fuchsia-500" : "bg-zinc-700"}`} />
-        </div>
-
-        {step === 1 && (
-          <PersonalDetailsStep onSubmit={submitProfile} />
-        )}
-        {step === 2 && (
-          <NewProjectStep onSubmit={submitProject} onBack={() => setStep(1)} />
-        )}
-      </div>
-    </main>
-  );
-}
-```
-
----
-
-### Step 1 — `PersonalDetailsStep.tsx`
-
-Key elements:
-- `<UserCircle size={56} weight="duotone" className="text-fuchsia-500 mx-auto mb-4" />`
-- Formik form with `first_name` and `last_name` text inputs
-- Error messages displayed below each field in `text-red-400 text-xs`
-- Submit button: full-width fuchsia rounded-full with `<ArrowRight />` icon
-
----
-
-### Step 2 — `NewProjectStep.tsx`
-
-Key elements:
-- `<Folder size={56} weight="duotone" className="text-fuchsia-500 mx-auto mb-4" />`
-- Project Name input — `onChange` auto-slugifies into the slug field unless user has manually edited slug
-- Slug input — locked by default; `<PencilSimple />` button toggles editable state; slug is prefixed with `spit.sh/` as a read-only label inline
-- Logo URL input — optional; if a valid URL is entered, renders `<img>` preview (32×32, rounded-full) beside the field using `<ImageSquare />` as placeholder
-- "Create Project" button (fuchsia, full-width) + "Back" ghost text link
-- `slugify` helper: `name.toLowerCase().replace(/\s+/g, "-").replace(/[^a-z0-9-]/g, "").slice(0, 30)`
+Uses a SQL COUNT JOIN to return projects with their link counts in a single query.
 
 ---
 
 ## Error Handling
 
-### Backend
-
-| Scenario | HTTP Status | Response body |
-|----------|-------------|---------------|
-| No/invalid JWT on any `/users/me` or `/projects/` endpoint | `401 Unauthorized` | `{ "detail": "Invalid or expired token" }` |
-| `user_id` from JWT does not exist in DB | `404 Not Found` | `{ "detail": "User not found" }` |
-| Slug already taken (`UNIQUE` constraint violation on `Project.slug`) | `409 Conflict` | `{ "detail": "Slug already taken" }` |
-| Validation failure (field too long, bad slug format) | `422 Unprocessable Entity` | Pydantic default error body |
-| Unexpected DB error | `500 Internal Server Error` | `{ "detail": "Internal server error" }` |
-
-**Implementation notes:**
-- In `crud/project.py`, wrap the `db.commit()` in a `try/except IntegrityError` and re-raise as `HTTPException(409)` when the slug conflicts.
-- The `update_user_profile` CRUD function raises `HTTPException(404)` directly if the user is not found — routers stay thin.
-- Do not leak raw SQLAlchemy error messages to the client.
-
----
-
-### Frontend
-
-**Per-field validation errors** — Yup + Formik surfaces these inline, below each input, in `text-red-400 text-xs`. These fire on blur and on submit attempt.
-
-**API error handling in `useOnboarding`** — uses `useToast` for all API-level feedback:
-
-```typescript
-const { showToast } = useToast();
-
-const submitProfile = async (values) => {
-  try {
-    await updateProfile(values, token);
-    showToast("Profile saved!", "success");
-    setStep(2);
-  } catch {
-    showToast("Something went wrong. Please try again.", "error");
-  }
-};
-
-const submitProject = async (values) => {
-  try {
-    await createProject(values, token);
-    showToast("Project created!", "success");
-    router.push("/dashboard");
-  } catch (err: any) {
-    if (err?.response?.status === 409) {
-      showToast("That slug is already taken. Please choose another.", "warning");
-    } else {
-      showToast("Something went wrong. Please try again.", "error");
-    }
-  }
-};
-```
-
-**Rule:** Per-field Yup validation errors remain inline (below each input, `text-red-400 text-xs`). Toasts are reserved for API responses and system-level events only — not field validation.
-
-**Loading state:** Both submit handlers set `isLoading: true` on entry and `false` on exit (success or error). The CTA button shows a `<CircleNotch className="animate-spin" />` icon and is `disabled` while loading.
-
-**Network/auth failures:** If the session token is absent when the page mounts, show `showToast("Please sign in to continue.", "warning")` then redirect to `/signin`.
-
----
-
-## Testing
-
-### Backend — `pytest` + `httpx AsyncClient`
-
-All tests use an in-memory SQLite DB (already the dev default). Use `pytest-asyncio` for async test functions.
-
-#### `tests/test_user_router.py`
-
-| Test | Expectation |
-|------|-------------|
-| `PATCH /users/me` with valid JWT + valid body | `200` + updated `first_name`/`last_name` in response |
-| `PATCH /users/me` with no Authorization header | `401` |
-| `PATCH /users/me` with `first_name` exceeding 20 chars | `422` |
-| `GET /users/me` with valid JWT | `200` + correct user fields |
-| `GET /users/me` with invalid token | `401` |
-
-#### `tests/test_project_router.py`
-
-| Test | Expectation |
-|------|-------------|
-| `POST /projects/` with valid JWT + valid body | `200` + `ProjectResponse` with correct fields |
-| `POST /projects/` duplicate slug | `409` with `"Slug already taken"` detail |
-| `POST /projects/` with no auth | `401` |
-| `POST /projects/` with slug containing uppercase | `422` |
-| `GET /projects/` returns only projects owned by the current user | `200` + list scoped to user |
-
-#### Test setup pattern
-
-```python
-import pytest
-from httpx import AsyncClient
-from jose import jwt
-from main import app
-from config.environment import settings
-
-def make_token(user_id: str) -> str:
-    return jwt.encode({"sub": user_id}, settings.better_auth_secret, algorithm="HS256")
-
-@pytest.mark.asyncio
-async def test_patch_users_me():
-    token = make_token("test-user-uuid")
-    async with AsyncClient(app=app, base_url="http://test") as client:
-        res = await client.patch(
-            "/api/v1/users/me",
-            json={"first_name": "Ada", "last_name": "Lovelace"},
-            headers={"Authorization": f"Bearer {token}"},
-        )
-    assert res.status_code == 200
-    assert res.json()["first_name"] == "Ada"
-```
-
----
-
-### Frontend — manual / integration
-
-Since the project has no automated frontend test setup, testing is manual against the running backend:
-
-| Scenario | Steps | Expected |
-|----------|-------|----------|
-| New user onboarding — happy path | Sign up → visit `/onboarding` → fill Step 1 → fill Step 2 | Lands on `/dashboard` |
-| Step 1 empty submit | Leave fields blank, click Continue | Inline errors appear, no API call made |
-| Step 1 API failure | Kill backend, submit | Error toast shown, button re-enabled |
-| Duplicate slug | Submit Step 2 with a slug that already exists | Warning toast: `"That slug is already taken"` |
-| Back button | Complete Step 1, go to Step 2, click Back | Returns to Step 1, Step 1 fields retain values |
-| Already onboarded | Visit `/onboarding` as user with `first_name` set | Redirected to `/dashboard` |
-| Unauthenticated | Visit `/onboarding` without session | Redirected to `/signin` |
-| Loading state | Submit either step with slow network | Button shows spinner, is disabled |
+| Scenario | Handling |
+|----------|----------|
+| No `spit_session` cookie on dashboard page | redirect to `/signin` |
+| `getProjectsAction()` throws (API error / 401) | redirect to `/onboarding` |
+| Profile update API error | error toast |
+| Project create — slug taken (409) | warning toast: "That slug is already taken" |
+| Project create — other error | error toast |
 
 ---
 
 ## Verification Checklist
 
-- [ ] New user signs up → lands on `/onboarding` (not `/dashboard`)
-- [ ] Step 1 form validates required fields and max lengths
-- [ ] Submitting Step 1 sends `PATCH /api/v1/users/me` and advances to Step 2
-- [ ] Project name typing auto-populates slug field
-- [ ] Slug field is locked until pencil icon is clicked
-- [ ] Logo URL preview renders when a valid image URL is entered
-- [ ] Submitting Step 2 sends `POST /api/v1/projects/` and redirects to `/dashboard`
-- [ ] Backend returns 401 on both endpoints without a valid JWT
-- [ ] Authenticated user with `first_name` set visiting `/onboarding` → redirected to `/dashboard`
-- [ ] Back button on Step 2 returns to Step 1 without resetting Step 1 data
+- [ ] New user signs in → lands on `/dashboard` → redirected to `/onboarding`
+- [ ] Completing onboarding → redirected to `/dashboard` → redirected to `/dashboard/<slug>`
+- [ ] Returning user with 1 project → skips dashboard home, lands directly on workspace
+- [ ] Returning user with 2+ projects → sees workspace card grid
+- [ ] Clicking a workspace card navigates to `/dashboard/<slug>`
+- [ ] Top bar logo links to `/dashboard`
+- [ ] User avatar/name click opens dropdown with Logout
+- [ ] Logout clears `spit_session` cookie and redirects to `/signin`
+- [ ] `/onboarding` guard redirects to `/dashboard` if user already has a project
+- [ ] JWT cookie is HTTP-only and not accessible from client JS

--- a/docs/prd/shared/onboarding-prd.md
+++ b/docs/prd/shared/onboarding-prd.md
@@ -1,0 +1,616 @@
+# Onboarding Flow — PRD
+
+## Overview
+
+When a user registers for the first time (via email OTP or OAuth), they are redirected through a 2-step onboarding flow before reaching the dashboard. The flow collects their personal profile details and creates their first project, ensuring they have a named workspace ready to use.
+
+**Trigger condition:** User is authenticated but `first_name` is `null`.
+
+---
+
+## User Flow
+
+```
+Sign up / First login
+        ↓
+/onboarding  →  Step 1: Personal Details  →  Step 2: New Project  →  /dashboard
+```
+
+Returning users with `first_name` set who navigate to `/onboarding` are redirected to `/dashboard`.
+
+---
+
+## Design
+
+### Layout
+- Full-height page with a subtle dark gradient background (`from-zinc-950 to-zinc-900`)
+- Single centered card (`max-w-md`, white/zinc-900 dark, rounded-2xl, shadow-xl)
+- Step progress indicator: 2 dots at the top of the card (fuchsia active, zinc inactive)
+- Logo/wordmark at the very top of the page (above the card)
+
+### Brand & Style
+- **Primary accent:** `fuchsia-600`
+- **Primary button:** `bg-fuchsia-600 text-white px-8 py-3 rounded-full font-semibold hover:bg-fuchsia-700 focus:ring focus:outline-none focus:ring-offset-2 focus:ring-fuchsia-200 transition-all`
+- **Ghost/back button:** `text-zinc-400 hover:text-zinc-200 transition-colors`
+- **Input fields:** `w-full rounded-xl border border-zinc-200 dark:border-zinc-700 bg-transparent px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-fuchsia-500`
+- **Icons:** Phosphor Icons (`@phosphor-icons/react`) — `weight="duotone"` for hero icons, `weight="regular"` for inline
+
+---
+
+## Step 1 — Personal Details
+
+### UI
+- **Hero icon:** `<UserCircle size={56} weight="duotone" className="text-fuchsia-500" />`
+- **Heading:** "Welcome to Spit.sh"
+- **Subheading:** "Let's set up your profile first."
+- **Fields:**
+  - First Name (required)
+  - Last Name (required)
+- **CTA:** "Continue" with `<ArrowRight />` icon (fuchsia primary button, full width)
+
+### Validation (Yup)
+```
+first_name: string, required, max 20 chars
+last_name:  string, required, max 25 chars
+```
+
+### On Submit
+- `PATCH /api/v1/users/me` with `{ first_name, last_name }`
+- On success → advance to Step 2
+
+---
+
+## Step 2 — New Project
+
+### UI
+- **Hero icon:** `<Folder size={56} weight="duotone" className="text-fuchsia-500" />`
+- **Heading:** "Create your first project"
+- **Subheading:** "Projects help you organise and share links."
+- **Fields:**
+  - Project Name (required, max 20 chars)
+  - Slug — auto-derived from name (slugified), editable; shows `<PencilSimple />` icon button to unlock editing; prefix label shows `spit.sh/`
+  - Logo URL (optional) — text input with `<ImageSquare />` icon; if a valid URL is entered, show a small circular preview beside the field
+- **Buttons:**
+  - "Create Project" with `<ArrowRight />` (fuchsia primary, full width)
+  - "Back" text link above or below (ghost, navigates back to Step 1)
+
+### Slug Auto-generation Rule
+Derived from project name: lowercase, spaces → hyphens, strip non-alphanumeric (except hyphens), max 30 chars. Regenerated live as the user types the name unless the user has manually edited the slug field.
+
+### Validation (Yup)
+```
+name: string, required, max 20 chars
+slug: string, required, max 30 chars, matches /^[a-z0-9-]+$/
+logo: string, optional, valid URL when present
+```
+
+### On Submit
+- `POST /api/v1/projects/` with `{ name, slug, logo? }`
+- On success → redirect to `/dashboard`
+
+---
+
+## Backend
+
+### 1. Model Change — `be/models/base.py`
+
+Add `image` field to `User`:
+
+```python
+image: Optional[str] = Field(default=None, nullable=True)
+```
+
+> No Alembic migration needed — dev uses SQLite with auto `create_all`.
+
+---
+
+### 2. Schemas
+
+#### `be/schemas/userSchema.py` — additions
+
+```python
+class UpdateProfileRequest(BaseModel):
+    first_name: str = Field(..., max_length=20)
+    last_name: str = Field(..., max_length=25)
+    image: Optional[str] = None
+
+class UserProfileResponse(BaseModel):
+    id: uuid.UUID
+    email: str
+    username: Optional[str]
+    first_name: Optional[str]
+    last_name: Optional[str]
+    image: Optional[str]
+    joined_at: datetime
+```
+
+#### `be/schemas/projectSchema.py` — new file
+
+```python
+from pydantic import BaseModel
+from typing import Optional
+from datetime import datetime
+import uuid
+
+class ProjectCreate(BaseModel):
+    name: str = Field(..., max_length=20)
+    slug: str = Field(..., max_length=30, regex=r"^[a-z0-9-]+$")
+    logo: Optional[str] = None
+
+class ProjectResponse(BaseModel):
+    id: uuid.UUID
+    name: str
+    slug: str
+    logo: Optional[str]
+    created_at: datetime
+```
+
+---
+
+### 3. CRUD
+
+#### `be/crud/user.py` — add `update_user_profile`
+
+```python
+async def update_user_profile(
+    user_id: uuid.UUID,
+    data: UpdateProfileRequest,
+    db: AsyncSession,
+) -> User:
+    result = await db.execute(select(User).where(User.id == user_id))
+    user = result.scalars().one_or_none()
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+    user.first_name = data.first_name
+    user.last_name = data.last_name
+    if data.image is not None:
+        user.image = data.image
+    await db.commit()
+    await db.refresh(user)
+    return user
+```
+
+#### `be/crud/project.py` — new file
+
+```python
+async def create_project(
+    data: ProjectCreate,
+    user_id: uuid.UUID,
+    db: AsyncSession,
+) -> Project:
+    project = Project(name=data.name, slug=data.slug, logo=data.logo)
+    db.add(project)
+    await db.flush()  # get project.id before commit
+    membership = ProjectUsers(
+        project_id=project.id,
+        user_id=user_id,
+        role=ProjectRole.Onwer,
+    )
+    db.add(membership)
+    await db.commit()
+    await db.refresh(project)
+    return project
+```
+
+---
+
+### 4. Routers
+
+#### `be/routers/userRouter.py` — new file
+
+```
+GET   /users/me    → get current user profile
+PATCH /users/me    → update profile (first_name, last_name, image)
+```
+
+Both endpoints require auth (`Depends(get_current_user)` from `utils/jwt_auth.py`). Extract `user_id` from JWT payload `sub` field.
+
+Response model: `UserProfileResponse`.
+
+#### `be/routers/projectRouter.py` — new file
+
+```
+POST /projects/    → create project + owner membership
+GET  /projects/    → list projects for current user
+```
+
+Both require auth. `POST` returns `ProjectResponse`. `GET` returns `List[ProjectResponse]`.
+
+For `GET /projects/`: query `ProjectUsers` joined to `Project` where `user_id = current_user_id`.
+
+---
+
+### 5. Register Routers — `be/main.py`
+
+```python
+from routers import linkRouter, userRouter, projectRouter
+
+configure_routes([linkRouter.router, userRouter.router, projectRouter.router])
+```
+
+---
+
+## Frontend
+
+### New Files
+
+| Path | Purpose |
+|------|---------|
+| `frontend/app/onboarding/page.tsx` | Page container, manages `step` state (1 \| 2) |
+| `frontend/components/onboarding/PersonalDetailsStep.tsx` | Step 1 form |
+| `frontend/components/onboarding/NewProjectStep.tsx` | Step 2 form |
+| `frontend/lib/queries/user.ts` | `updateProfile()`, `getProfile()` API calls |
+| `frontend/lib/queries/project.ts` | `createProject()`, `getProjects()` API calls |
+| `frontend/hooks/useOnboarding.ts` | Step state + submission logic |
+| `frontend/hooks/useToast.ts` | Thin wrapper around sonner for typed toast notifications |
+
+---
+
+### Toast System
+
+**Install:** `pnpm dlx shadcn@latest add sonner`
+
+**`<Toaster />`** must be mounted once in the root layout (`frontend/app/layout.tsx`):
+
+```tsx
+import { Toaster } from "@/components/ui/sonner";
+
+// inside <body>:
+<Toaster position="bottom-right" richColors />
+```
+
+---
+
+#### Hook — `frontend/hooks/useToast.ts`
+
+```typescript
+import { toast } from "sonner";
+
+type ToastState = "success" | "warning" | "error" | "neutral";
+
+export function useToast() {
+  const showToast = (message: string, state: ToastState = "neutral") => {
+    switch (state) {
+      case "success":
+        toast.success(message);
+        break;
+      case "warning":
+        toast.warning(message);
+        break;
+      case "error":
+        toast.error(message);
+        break;
+      case "neutral":
+      default:
+        toast(message);
+    }
+  };
+
+  return { showToast };
+}
+```
+
+**Usage anywhere in the app:**
+```typescript
+const { showToast } = useToast();
+
+showToast("Profile saved.", "success");
+showToast("Slug already taken.", "error");
+showToast("Redirecting you to the dashboard…", "neutral");
+```
+
+**Toast states mapped to sonner:**
+
+| State | Sonner call | Visual (richColors) |
+|-------|-------------|---------------------|
+| `success` | `toast.success()` | Green icon + border |
+| `warning` | `toast.warning()` | Amber icon + border |
+| `error` | `toast.error()` | Red icon + border |
+| `neutral` | `toast()` | Default zinc styling |
+
+---
+
+### API Queries
+
+#### `frontend/lib/queries/user.ts`
+
+```typescript
+import axios from "axios";
+import { API_URL } from "@/lib/config/public_env";
+
+export const updateProfile = async (
+  data: { first_name: string; last_name: string; image?: string },
+  token: string
+) => {
+  const res = await axios.patch(`${API_URL}/users/me`, data, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  return res.data;
+};
+
+export const getProfile = async (token: string) => {
+  const res = await axios.get(`${API_URL}/users/me`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  return res.data;
+};
+```
+
+#### `frontend/lib/queries/project.ts`
+
+```typescript
+import axios from "axios";
+import { API_URL } from "@/lib/config/public_env";
+
+export const createProject = async (
+  data: { name: string; slug: string; logo?: string },
+  token: string
+) => {
+  const res = await axios.post(`${API_URL}/projects/`, data, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  return res.data;
+};
+```
+
+---
+
+### Hook — `frontend/hooks/useOnboarding.ts`
+
+```typescript
+"use client";
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { updateProfile, createProject } from "@/lib/queries";
+
+export function useOnboarding(token: string) {
+  const [step, setStep] = useState<1 | 2>(1);
+  const router = useRouter();
+
+  const submitProfile = async (values: { first_name: string; last_name: string }) => {
+    await updateProfile(values, token);
+    setStep(2);
+  };
+
+  const submitProject = async (values: { name: string; slug: string; logo?: string }) => {
+    await createProject(values, token);
+    router.push("/dashboard");
+  };
+
+  return { step, setStep, submitProfile, submitProject };
+}
+```
+
+---
+
+### Middleware Update — `frontend/middleware.ts`
+
+After the existing session auth check, add:
+
+```typescript
+// Redirect authenticated users without a profile to onboarding
+if (session?.user && !session.user.name?.includes(" ")) {
+  // Better: check first_name from a custom session field or API call
+  // For now: redirect /dashboard → /onboarding if firstName is absent
+  if (req.nextUrl.pathname.startsWith("/dashboard") && !session.user.firstName) {
+    return NextResponse.redirect(new URL("/onboarding", req.url));
+  }
+}
+// Redirect completed users away from onboarding
+if (req.nextUrl.pathname.startsWith("/onboarding") && session?.user?.firstName) {
+  return NextResponse.redirect(new URL("/dashboard", req.url));
+}
+```
+
+> **Note:** `better-auth` may need the `firstName` field exposed in the session. If not available by default, fetch `/api/v1/users/me` inside the onboarding page on mount and redirect if already complete.
+
+---
+
+### Onboarding Page — `frontend/app/onboarding/page.tsx`
+
+```tsx
+"use client";
+import { useSession } from "@/lib/auth-client";
+import { useOnboarding } from "@/hooks/useOnboarding";
+import PersonalDetailsStep from "@/components/onboarding/PersonalDetailsStep";
+import NewProjectStep from "@/components/onboarding/NewProjectStep";
+
+export default function OnboardingPage() {
+  const { data: session } = useSession();
+  const token = session?.session?.token ?? "";
+  const { step, setStep, submitProfile, submitProject } = useOnboarding(token);
+
+  return (
+    <main className="min-h-screen bg-gradient-to-br from-zinc-950 to-zinc-900 flex flex-col items-center justify-center px-4">
+      {/* Logo */}
+      <div className="mb-8 text-2xl font-bold text-white tracking-tight">
+        spit<span className="text-fuchsia-500">.sh</span>
+      </div>
+
+      {/* Card */}
+      <div className="w-full max-w-md bg-zinc-900 border border-zinc-800 rounded-2xl shadow-2xl p-8">
+        {/* Step dots */}
+        <div className="flex gap-2 justify-center mb-8">
+          <span className={`h-2 w-6 rounded-full transition-all ${step === 1 ? "bg-fuchsia-500" : "bg-zinc-700"}`} />
+          <span className={`h-2 w-6 rounded-full transition-all ${step === 2 ? "bg-fuchsia-500" : "bg-zinc-700"}`} />
+        </div>
+
+        {step === 1 && (
+          <PersonalDetailsStep onSubmit={submitProfile} />
+        )}
+        {step === 2 && (
+          <NewProjectStep onSubmit={submitProject} onBack={() => setStep(1)} />
+        )}
+      </div>
+    </main>
+  );
+}
+```
+
+---
+
+### Step 1 — `PersonalDetailsStep.tsx`
+
+Key elements:
+- `<UserCircle size={56} weight="duotone" className="text-fuchsia-500 mx-auto mb-4" />`
+- Formik form with `first_name` and `last_name` text inputs
+- Error messages displayed below each field in `text-red-400 text-xs`
+- Submit button: full-width fuchsia rounded-full with `<ArrowRight />` icon
+
+---
+
+### Step 2 — `NewProjectStep.tsx`
+
+Key elements:
+- `<Folder size={56} weight="duotone" className="text-fuchsia-500 mx-auto mb-4" />`
+- Project Name input — `onChange` auto-slugifies into the slug field unless user has manually edited slug
+- Slug input — locked by default; `<PencilSimple />` button toggles editable state; slug is prefixed with `spit.sh/` as a read-only label inline
+- Logo URL input — optional; if a valid URL is entered, renders `<img>` preview (32×32, rounded-full) beside the field using `<ImageSquare />` as placeholder
+- "Create Project" button (fuchsia, full-width) + "Back" ghost text link
+- `slugify` helper: `name.toLowerCase().replace(/\s+/g, "-").replace(/[^a-z0-9-]/g, "").slice(0, 30)`
+
+---
+
+## Error Handling
+
+### Backend
+
+| Scenario | HTTP Status | Response body |
+|----------|-------------|---------------|
+| No/invalid JWT on any `/users/me` or `/projects/` endpoint | `401 Unauthorized` | `{ "detail": "Invalid or expired token" }` |
+| `user_id` from JWT does not exist in DB | `404 Not Found` | `{ "detail": "User not found" }` |
+| Slug already taken (`UNIQUE` constraint violation on `Project.slug`) | `409 Conflict` | `{ "detail": "Slug already taken" }` |
+| Validation failure (field too long, bad slug format) | `422 Unprocessable Entity` | Pydantic default error body |
+| Unexpected DB error | `500 Internal Server Error` | `{ "detail": "Internal server error" }` |
+
+**Implementation notes:**
+- In `crud/project.py`, wrap the `db.commit()` in a `try/except IntegrityError` and re-raise as `HTTPException(409)` when the slug conflicts.
+- The `update_user_profile` CRUD function raises `HTTPException(404)` directly if the user is not found — routers stay thin.
+- Do not leak raw SQLAlchemy error messages to the client.
+
+---
+
+### Frontend
+
+**Per-field validation errors** — Yup + Formik surfaces these inline, below each input, in `text-red-400 text-xs`. These fire on blur and on submit attempt.
+
+**API error handling in `useOnboarding`** — uses `useToast` for all API-level feedback:
+
+```typescript
+const { showToast } = useToast();
+
+const submitProfile = async (values) => {
+  try {
+    await updateProfile(values, token);
+    showToast("Profile saved!", "success");
+    setStep(2);
+  } catch {
+    showToast("Something went wrong. Please try again.", "error");
+  }
+};
+
+const submitProject = async (values) => {
+  try {
+    await createProject(values, token);
+    showToast("Project created!", "success");
+    router.push("/dashboard");
+  } catch (err: any) {
+    if (err?.response?.status === 409) {
+      showToast("That slug is already taken. Please choose another.", "warning");
+    } else {
+      showToast("Something went wrong. Please try again.", "error");
+    }
+  }
+};
+```
+
+**Rule:** Per-field Yup validation errors remain inline (below each input, `text-red-400 text-xs`). Toasts are reserved for API responses and system-level events only — not field validation.
+
+**Loading state:** Both submit handlers set `isLoading: true` on entry and `false` on exit (success or error). The CTA button shows a `<CircleNotch className="animate-spin" />` icon and is `disabled` while loading.
+
+**Network/auth failures:** If the session token is absent when the page mounts, show `showToast("Please sign in to continue.", "warning")` then redirect to `/signin`.
+
+---
+
+## Testing
+
+### Backend — `pytest` + `httpx AsyncClient`
+
+All tests use an in-memory SQLite DB (already the dev default). Use `pytest-asyncio` for async test functions.
+
+#### `tests/test_user_router.py`
+
+| Test | Expectation |
+|------|-------------|
+| `PATCH /users/me` with valid JWT + valid body | `200` + updated `first_name`/`last_name` in response |
+| `PATCH /users/me` with no Authorization header | `401` |
+| `PATCH /users/me` with `first_name` exceeding 20 chars | `422` |
+| `GET /users/me` with valid JWT | `200` + correct user fields |
+| `GET /users/me` with invalid token | `401` |
+
+#### `tests/test_project_router.py`
+
+| Test | Expectation |
+|------|-------------|
+| `POST /projects/` with valid JWT + valid body | `200` + `ProjectResponse` with correct fields |
+| `POST /projects/` duplicate slug | `409` with `"Slug already taken"` detail |
+| `POST /projects/` with no auth | `401` |
+| `POST /projects/` with slug containing uppercase | `422` |
+| `GET /projects/` returns only projects owned by the current user | `200` + list scoped to user |
+
+#### Test setup pattern
+
+```python
+import pytest
+from httpx import AsyncClient
+from jose import jwt
+from main import app
+from config.environment import settings
+
+def make_token(user_id: str) -> str:
+    return jwt.encode({"sub": user_id}, settings.better_auth_secret, algorithm="HS256")
+
+@pytest.mark.asyncio
+async def test_patch_users_me():
+    token = make_token("test-user-uuid")
+    async with AsyncClient(app=app, base_url="http://test") as client:
+        res = await client.patch(
+            "/api/v1/users/me",
+            json={"first_name": "Ada", "last_name": "Lovelace"},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    assert res.status_code == 200
+    assert res.json()["first_name"] == "Ada"
+```
+
+---
+
+### Frontend — manual / integration
+
+Since the project has no automated frontend test setup, testing is manual against the running backend:
+
+| Scenario | Steps | Expected |
+|----------|-------|----------|
+| New user onboarding — happy path | Sign up → visit `/onboarding` → fill Step 1 → fill Step 2 | Lands on `/dashboard` |
+| Step 1 empty submit | Leave fields blank, click Continue | Inline errors appear, no API call made |
+| Step 1 API failure | Kill backend, submit | Error toast shown, button re-enabled |
+| Duplicate slug | Submit Step 2 with a slug that already exists | Warning toast: `"That slug is already taken"` |
+| Back button | Complete Step 1, go to Step 2, click Back | Returns to Step 1, Step 1 fields retain values |
+| Already onboarded | Visit `/onboarding` as user with `first_name` set | Redirected to `/dashboard` |
+| Unauthenticated | Visit `/onboarding` without session | Redirected to `/signin` |
+| Loading state | Submit either step with slow network | Button shows spinner, is disabled |
+
+---
+
+## Verification Checklist
+
+- [ ] New user signs up → lands on `/onboarding` (not `/dashboard`)
+- [ ] Step 1 form validates required fields and max lengths
+- [ ] Submitting Step 1 sends `PATCH /api/v1/users/me` and advances to Step 2
+- [ ] Project name typing auto-populates slug field
+- [ ] Slug field is locked until pencil icon is clicked
+- [ ] Logo URL preview renders when a valid image URL is entered
+- [ ] Submitting Step 2 sends `POST /api/v1/projects/` and redirects to `/dashboard`
+- [ ] Backend returns 401 on both endpoints without a valid JWT
+- [ ] Authenticated user with `first_name` set visiting `/onboarding` → redirected to `/dashboard`
+- [ ] Back button on Step 2 returns to Step 1 without resetting Step 1 data

--- a/docs/prd/shared/onboarding-prd.md
+++ b/docs/prd/shared/onboarding-prd.md
@@ -127,7 +127,7 @@ class UserProfileResponse(BaseModel):
 #### `be/schemas/projectSchema.py` — new file
 
 ```python
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from typing import Optional
 from datetime import datetime
 import uuid
@@ -151,16 +151,18 @@ class ProjectResponse(BaseModel):
 
 #### `be/crud/user.py` — add `update_user_profile`
 
+Returns `None` if the user doesn't exist — the router raises the 404. Keeps the CRUD layer free of HTTP concerns.
+
 ```python
 async def update_user_profile(
     user_id: uuid.UUID,
     data: UpdateProfileRequest,
     db: AsyncSession,
-) -> User:
+) -> Optional[User]:
     result = await db.execute(select(User).where(User.id == user_id))
     user = result.scalars().one_or_none()
     if not user:
-        raise HTTPException(status_code=404, detail="User not found")
+        return None
     user.first_name = data.first_name
     user.last_name = data.last_name
     if data.image is not None:
@@ -172,7 +174,12 @@ async def update_user_profile(
 
 #### `be/crud/project.py` — new file
 
+Catches `IntegrityError` (slug conflict) and re-raises as `HTTPException(409)`. All other DB errors propagate naturally.
+
 ```python
+from sqlalchemy.exc import IntegrityError
+from fastapi import HTTPException
+
 async def create_project(
     data: ProjectCreate,
     user_id: uuid.UUID,
@@ -180,7 +187,11 @@ async def create_project(
 ) -> Project:
     project = Project(name=data.name, slug=data.slug, logo=data.logo)
     db.add(project)
-    await db.flush()  # get project.id before commit
+    try:
+        await db.flush()
+    except IntegrityError:
+        await db.rollback()
+        raise HTTPException(status_code=409, detail="Slug already taken")
     membership = ProjectUsers(
         project_id=project.id,
         user_id=user_id,
@@ -191,6 +202,8 @@ async def create_project(
     await db.refresh(project)
     return project
 ```
+
+> Note: `IntegrityError` from a slug conflict is a data-level concern so it's acceptable to raise `HTTPException` here. The router stays thin.
 
 ---
 
@@ -361,7 +374,8 @@ export const createProject = async (
 "use client";
 import { useState } from "react";
 import { useRouter } from "next/navigation";
-import { updateProfile, createProject } from "@/lib/queries";
+import { updateProfile } from "@/lib/queries/user";
+import { createProject } from "@/lib/queries/project";
 
 export function useOnboarding(token: string) {
   const [step, setStep] = useState<1 | 2>(1);
@@ -377,7 +391,7 @@ export function useOnboarding(token: string) {
     router.push("/dashboard");
   };
 
-  return { step, setStep, submitProfile, submitProject };
+  return { step, setStep, isLoading, submitProfile, submitProject };
 }
 ```
 
@@ -385,24 +399,23 @@ export function useOnboarding(token: string) {
 
 ### Middleware Update — `frontend/middleware.ts`
 
-After the existing session auth check, add:
+Add `/onboarding` to the list of protected routes (requires session). Then add redirect logic after the existing session check:
 
 ```typescript
-// Redirect authenticated users without a profile to onboarding
-if (session?.user && !session.user.name?.includes(" ")) {
-  // Better: check first_name from a custom session field or API call
-  // For now: redirect /dashboard → /onboarding if firstName is absent
-  if (req.nextUrl.pathname.startsWith("/dashboard") && !session.user.firstName) {
-    return NextResponse.redirect(new URL("/onboarding", req.url));
-  }
+// Unauthenticated users hitting /onboarding → /signin (handled by existing protected route guard)
+
+// Authenticated users without first_name → redirect /dashboard to /onboarding
+if (req.nextUrl.pathname.startsWith("/dashboard") && !session.user.firstName) {
+  return NextResponse.redirect(new URL("/onboarding", req.url));
 }
-// Redirect completed users away from onboarding
-if (req.nextUrl.pathname.startsWith("/onboarding") && session?.user?.firstName) {
+
+// Authenticated users who completed onboarding → redirect /onboarding to /dashboard
+if (req.nextUrl.pathname.startsWith("/onboarding") && session.user.firstName) {
   return NextResponse.redirect(new URL("/dashboard", req.url));
 }
 ```
 
-> **Note:** `better-auth` may need the `firstName` field exposed in the session. If not available by default, fetch `/api/v1/users/me` inside the onboarding page on mount and redirect if already complete.
+> `session.user.firstName` requires `better-auth` to expose the field. If it isn't available in the session object by default, handle the redirect inside `onboarding/page.tsx` on mount: call `getProfile(token)` and `router.replace("/dashboard")` if `first_name` is already set.
 
 ---
 

--- a/frontend/app/(auth)/callback/route.ts
+++ b/frontend/app/(auth)/callback/route.ts
@@ -1,0 +1,30 @@
+import { NextRequest, NextResponse } from "next/server";
+import { SignJWT } from "jose";
+import { auth } from "@/lib/auth";
+import { BETTER_AUTH_SECRET } from "@/lib/config/environment";
+
+export async function GET(request: NextRequest) {
+  const session = await auth.api.getSession({ headers: request.headers });
+
+  if (!session?.user?.id) {
+    return NextResponse.redirect(new URL("/signin", request.url));
+  }
+
+  const secret = new TextEncoder().encode(BETTER_AUTH_SECRET);
+  const token = await new SignJWT({ sub: session.user.id })
+    .setProtectedHeader({ alg: "HS256" })
+    .setIssuedAt()
+    .setExpirationTime("30d")
+    .sign(secret);
+
+  const response = NextResponse.redirect(new URL("/dashboard", request.url));
+  response.cookies.set("spit_session", token, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax",
+    path: "/",
+    maxAge: 60 * 60 * 24 * 30,
+  });
+
+  return response;
+}

--- a/frontend/app/(auth)/signin/page.tsx
+++ b/frontend/app/(auth)/signin/page.tsx
@@ -35,7 +35,7 @@ export default function SignInPage() {
   };
 
   const handleSocialSignIn = async (provider: "google" | "github") => {
-    await authClient.signIn.social({ provider, callbackURL: "/dashboard" });
+    await authClient.signIn.social({ provider, callbackURL: "/callback" });
   };
 
   return (

--- a/frontend/app/(auth)/verify/page.tsx
+++ b/frontend/app/(auth)/verify/page.tsx
@@ -12,6 +12,7 @@ import {
   InputOTPSlot,
 } from "@/components/ui/input-otp";
 import { REGEXP_ONLY_DIGITS } from "input-otp";
+import { setUserCookie } from "@/app/actions/auth";
 
 function VerifyForm() {
   const router = useRouter();
@@ -28,13 +29,21 @@ function VerifyForm() {
     setIsVerifying(true);
     setError("");
 
-    const { error } = await authClient.signIn.emailOtp({ email, otp: code });
+    const { data, error } = await authClient.signIn.emailOtp({
+      email,
+      otp: code,
+    });
 
     setIsVerifying(false);
 
     if (error) {
       setError(error.message ?? "Invalid code. Please try again.");
       return;
+    }
+
+    const userId = data?.user?.id;
+    if (userId) {
+      await setUserCookie(userId);
     }
 
     router.push("/dashboard");

--- a/frontend/app/actions/auth.ts
+++ b/frontend/app/actions/auth.ts
@@ -1,0 +1,39 @@
+"use server";
+
+import { cookies } from "next/headers";
+import { SignJWT, jwtVerify } from "jose";
+import { BETTER_AUTH_SECRET } from "@/lib/config/environment";
+
+const COOKIE_NAME = "spit_session";
+const secret = new TextEncoder().encode(BETTER_AUTH_SECRET);
+
+export async function setUserCookie(userId: string) {
+  const token = await new SignJWT({ sub: userId })
+    .setProtectedHeader({ alg: "HS256" })
+    .setIssuedAt()
+    .setExpirationTime("30d")
+    .sign(secret);
+
+  cookies().set(COOKIE_NAME, token, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax",
+    path: "/",
+    maxAge: 60 * 60 * 24 * 30,
+  });
+}
+
+export async function deleteUserCookie() {
+  cookies().delete(COOKIE_NAME);
+}
+
+export async function getSessionToken(): Promise<string | null> {
+  const cookie = cookies().get(COOKIE_NAME);
+  if (!cookie) return null;
+  try {
+    await jwtVerify(cookie.value, secret);
+    return cookie.value;
+  } catch {
+    return null;
+  }
+}

--- a/frontend/app/actions/project.ts
+++ b/frontend/app/actions/project.ts
@@ -1,0 +1,27 @@
+"use server";
+
+import axios from "axios";
+import { API_URL } from "@/lib/config/public_env";
+import { getSessionToken } from "./auth";
+
+export async function getProjectsAction() {
+  const token = await getSessionToken();
+  if (!token) throw new Error("Unauthorized");
+  const res = await axios.get(`${API_URL}/projects/`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  return res.data;
+}
+
+export async function createProjectAction(data: {
+  name: string;
+  slug: string;
+  logo?: string;
+}) {
+  const token = await getSessionToken();
+  if (!token) throw new Error("Unauthorized");
+  const res = await axios.post(`${API_URL}/projects/`, data, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  return res.data;
+}

--- a/frontend/app/actions/user.ts
+++ b/frontend/app/actions/user.ts
@@ -1,0 +1,18 @@
+"use server";
+
+import axios from "axios";
+import { API_URL } from "@/lib/config/public_env";
+import { getSessionToken } from "./auth";
+
+export async function updateProfileAction(data: {
+  first_name: string;
+  last_name: string;
+  image?: string;
+}) {
+  const token = await getSessionToken();
+  if (!token) throw new Error("Unauthorized");
+  const res = await axios.patch(`${API_URL}/users/me`, data, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  return res.data;
+}

--- a/frontend/app/dashboard/[project-slug]/layout.tsx
+++ b/frontend/app/dashboard/[project-slug]/layout.tsx
@@ -1,5 +1,5 @@
 import DashboardLayout from "@/layouts/DashboardLayout";
-import { Metadata } from "next/dist/lib/metadata/types/metadata-interface";
+import type { Metadata } from "next";
 
 export const metadata: Metadata = {
   title: "Spit.sh - Dashboard",

--- a/frontend/app/dashboard/[project-slug]/layout.tsx
+++ b/frontend/app/dashboard/[project-slug]/layout.tsx
@@ -1,14 +1,15 @@
 import DashboardLayout from "@/layouts/DashboardLayout";
 import { Metadata } from "next/dist/lib/metadata/types/metadata-interface";
-import React, { FC, PropsWithChildren } from "react";
 
 export const metadata: Metadata = {
   title: "Spit.sh - Dashboard",
   description: "Get more out of your links with analytics and tracking",
 };
 
-const DashLayout: FC<PropsWithChildren> = ({ children }) => {
+export default async function DashLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
   return <DashboardLayout>{children}</DashboardLayout>;
-};
-
-export default DashLayout;
+}

--- a/frontend/app/dashboard/[project-slug]/page.tsx
+++ b/frontend/app/dashboard/[project-slug]/page.tsx
@@ -1,0 +1,47 @@
+export default function DashboardPage() {
+  return (
+    <section>
+      <header className='flex w-full justify-between'>
+        <h1 className='text-2xl text-zinc-900 dark:text-zinc-200 mb-3 font-semibold'>
+          Home
+        </h1>
+        <button className='inline-flex items-center rounded-full bg-fuchsia-600 px-8 py-3 text-sm font-semibold text-white gap-x-1 focus:outline-none focus:ring active:bg-indigo-500'>
+          <span>Create new link</span>
+          <svg
+            xmlns='http://www.w3.org/2000/svg'
+            width='24'
+            height='24'
+            fill='currentColor'
+            viewBox='0 0 256 256'
+          >
+            <path d='M128,24A104,104,0,1,0,232,128,104.11,104.11,0,0,0,128,24Zm0,192a88,88,0,1,1,88-88A88.1,88.1,0,0,1,128,216Zm48-88a8,8,0,0,1-8,8H136v32a8,8,0,0,1-16,0V136H88a8,8,0,0,1,0-16h32V88a8,8,0,0,1,16,0v32h32A8,8,0,0,1,176,128Z'></path>
+          </svg>
+        </button>
+      </header>
+      <div className='flex flex-col justify-center gap-y-4 items-center place-items-center h-[600px] w-full text-zinc-700 dark:text-zinc-300'>
+        <svg
+          xmlns='http://www.w3.org/2000/svg'
+          width='200'
+          height='200'
+          fill='currentColor'
+          viewBox='0 0 256 256'
+        >
+          <path d='M128,24A104,104,0,1,0,232,128,104.11,104.11,0,0,0,128,24Zm0,16a87.5,87.5,0,0,1,48,14.28V74L153.83,99.74,122.36,104l-.31-.22L102.38,90.92A16,16,0,0,0,79.87,95.1L58.93,126.4a16,16,0,0,0-2.7,8.81L56,171.44l-3.27,2.15A88,88,0,0,1,128,40ZM62.29,186.47l2.52-1.65A16,16,0,0,0,72,171.53l.21-36.23L93.17,104a3.62,3.62,0,0,0,.32.22l19.67,12.87a15.94,15.94,0,0,0,11.35,2.77L156,115.59a16,16,0,0,0,10-5.41l22.17-25.76A16,16,0,0,0,192,74V67.67A87.87,87.87,0,0,1,211.77,155l-16.14-14.76a16,16,0,0,0-16.93-3l-30.46,12.65a16.08,16.08,0,0,0-9.68,12.45l-2.39,16.19a16,16,0,0,0,11.77,17.81L169.4,202l2.36,2.37A87.88,87.88,0,0,1,62.29,186.47ZM185,195l-4.3-4.31a16,16,0,0,0-7.26-4.18L152,180.85l2.39-16.19L184.84,152,205,170.48A88.43,88.43,0,0,1,185,195Z'></path>
+        </svg>
+        <p className='text-sm md:text-base'>No links yet</p>
+        <button className='inline-flex items-center rounded-full bg-fuchsia-600 px-8 py-3 transition hover:rotate-6 text-sm font-semibold text-white gap-x-1 focus:outline-none focus:ring active:bg-indigo-500 mt-4'>
+          <span>Create new link</span>
+          <svg
+            xmlns='http://www.w3.org/2000/svg'
+            width='24'
+            height='24'
+            fill='currentColor'
+            viewBox='0 0 256 256'
+          >
+            <path d='M128,24A104,104,0,1,0,232,128,104.11,104.11,0,0,0,128,24Zm0,192a88,88,0,1,1,88-88A88.1,88.1,0,0,1,128,216Zm48-88a8,8,0,0,1-8,8H136v32a8,8,0,0,1-16,0V136H88a8,8,0,0,1,0-16h32V88a8,8,0,0,1,16,0v32h32A8,8,0,0,1,176,128Z'></path>
+          </svg>
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/frontend/app/dashboard/layout.tsx
+++ b/frontend/app/dashboard/layout.tsx
@@ -1,0 +1,14 @@
+import DashboardLayout from "@/layouts/DashboardLayout";
+import { Metadata } from "next/dist/lib/metadata/types/metadata-interface";
+import React, { FC, PropsWithChildren } from "react";
+
+export const metadata: Metadata = {
+  title: "Spit.sh - Dashboard",
+  description: "Get more out of your links with analytics and tracking",
+};
+
+const DashLayout: FC<PropsWithChildren> = ({ children }) => {
+  return <DashboardLayout>{children}</DashboardLayout>;
+};
+
+export default DashLayout;

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -1,6 +1,5 @@
 import { redirect } from "next/navigation";
 import Link from "next/link";
-import { getSessionToken } from "@/app/actions/auth";
 import { getProjectsAction } from "@/app/actions/project";
 import DashboardHomeNavbar from "@/components/DashboardHomeNavbar";
 

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -1,47 +1,56 @@
-export default function DashboardPage() {
+import { redirect } from "next/navigation";
+import Link from "next/link";
+import { getSessionToken } from "@/app/actions/auth";
+import { getProjectsAction } from "@/app/actions/project";
+import DashboardHomeNavbar from "@/components/DashboardHomeNavbar";
+
+interface Project {
+  id: string;
+  name: string;
+  slug: string;
+  logo?: string | null;
+  links_count: number;
+}
+
+export default async function DashboardPage() {
+  let projects: Project[] = [];
+  try {
+    projects = await getProjectsAction();
+  } catch {
+    redirect("/onboarding");
+  }
+
+  if (projects.length === 0) redirect("/onboarding");
+  if (projects.length === 1) redirect(`/dashboard/${projects[0].slug}`);
+
   return (
-    <section>
-      <header className='flex w-full justify-between'>
-        <h1 className='text-2xl text-zinc-900 dark:text-zinc-200 mb-3 font-semibold'>
-          Home
-        </h1>
-        <button className='inline-flex items-center rounded-full bg-fuchsia-600 px-8 py-3 text-sm font-semibold text-white gap-x-1 focus:outline-none focus:ring active:bg-indigo-500'>
-          <span>Create new link</span>
-          <svg
-            xmlns='http://www.w3.org/2000/svg'
-            width='24'
-            height='24'
-            fill='currentColor'
-            viewBox='0 0 256 256'
-          >
-            <path d='M128,24A104,104,0,1,0,232,128,104.11,104.11,0,0,0,128,24Zm0,192a88,88,0,1,1,88-88A88.1,88.1,0,0,1,128,216Zm48-88a8,8,0,0,1-8,8H136v32a8,8,0,0,1-16,0V136H88a8,8,0,0,1,0-16h32V88a8,8,0,0,1,16,0v32h32A8,8,0,0,1,176,128Z'></path>
-          </svg>
-        </button>
-      </header>
-      <div className='flex flex-col justify-center gap-y-4 items-center place-items-center h-[600px] w-full text-zinc-700 dark:text-zinc-300'>
-        <svg
-          xmlns='http://www.w3.org/2000/svg'
-          width='200'
-          height='200'
-          fill='currentColor'
-          viewBox='0 0 256 256'
-        >
-          <path d='M128,24A104,104,0,1,0,232,128,104.11,104.11,0,0,0,128,24Zm0,16a87.5,87.5,0,0,1,48,14.28V74L153.83,99.74,122.36,104l-.31-.22L102.38,90.92A16,16,0,0,0,79.87,95.1L58.93,126.4a16,16,0,0,0-2.7,8.81L56,171.44l-3.27,2.15A88,88,0,0,1,128,40ZM62.29,186.47l2.52-1.65A16,16,0,0,0,72,171.53l.21-36.23L93.17,104a3.62,3.62,0,0,0,.32.22l19.67,12.87a15.94,15.94,0,0,0,11.35,2.77L156,115.59a16,16,0,0,0,10-5.41l22.17-25.76A16,16,0,0,0,192,74V67.67A87.87,87.87,0,0,1,211.77,155l-16.14-14.76a16,16,0,0,0-16.93-3l-30.46,12.65a16.08,16.08,0,0,0-9.68,12.45l-2.39,16.19a16,16,0,0,0,11.77,17.81L169.4,202l2.36,2.37A87.88,87.88,0,0,1,62.29,186.47ZM185,195l-4.3-4.31a16,16,0,0,0-7.26-4.18L152,180.85l2.39-16.19L184.84,152,205,170.48A88.43,88.43,0,0,1,185,195Z'></path>
-        </svg>
-        <p className='text-sm md:text-base'>No links yet</p>
-        <button className='inline-flex items-center rounded-full bg-fuchsia-600 px-8 py-3 transition hover:rotate-6 text-sm font-semibold text-white gap-x-1 focus:outline-none focus:ring active:bg-indigo-500 mt-4'>
-          <span>Create new link</span>
-          <svg
-            xmlns='http://www.w3.org/2000/svg'
-            width='24'
-            height='24'
-            fill='currentColor'
-            viewBox='0 0 256 256'
-          >
-            <path d='M128,24A104,104,0,1,0,232,128,104.11,104.11,0,0,0,128,24Zm0,192a88,88,0,1,1,88-88A88.1,88.1,0,0,1,128,216Zm48-88a8,8,0,0,1-8,8H136v32a8,8,0,0,1-16,0V136H88a8,8,0,0,1,0-16h32V88a8,8,0,0,1,16,0v32h32A8,8,0,0,1,176,128Z'></path>
-          </svg>
-        </button>
-      </div>
-    </section>
+    <div className='min-h-screen bg-zinc-950 text-zinc-100'>
+      <DashboardHomeNavbar />
+      <main className='px-8 py-10'>
+        <section aria-labelledby='workspaces-heading'>
+          <h1 id='workspaces-heading' className='sr-only'>
+            Your workspaces
+          </h1>
+          <ul className='grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5 list-none'>
+            {projects.map((project) => (
+              <li key={project.id}>
+                <Link
+                  href={`/dashboard/${project.slug}`}
+                  className='flex flex-col justify-between border border-zinc-700 rounded-xl p-6 h-44 hover:border-fuchsia-500 hover:bg-zinc-800/30 transition-all'
+                >
+                  <h2 className='text-base font-semibold text-zinc-100'>
+                    {project.name}
+                  </h2>
+                  <p className='text-sm text-zinc-400'>
+                    {project.links_count} active{" "}
+                    {project.links_count === 1 ? "link" : "links"}
+                  </p>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </section>
+      </main>
+    </div>
   );
 }

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -1,51 +1,47 @@
-import DashboardLayout from "@/layouts/DashboardLayout";
-
 export default function DashboardPage() {
   return (
-    <DashboardLayout title='Home'>
-      <section>
-        <header className='flex w-full justify-between'>
-          <h1 className='text-2xl text-zinc-900 dark:text-zinc-200 mb-3 font-semibold'>
-            Home
-          </h1>
-          <button className='inline-flex items-center rounded-full bg-fuchsia-600 px-8 py-3 text-sm font-semibold text-white gap-x-1 focus:outline-none focus:ring active:bg-indigo-500'>
-            <span>Create new link</span>
-            <svg
-              xmlns='http://www.w3.org/2000/svg'
-              width='24'
-              height='24'
-              fill='currentColor'
-              viewBox='0 0 256 256'
-            >
-              <path d='M128,24A104,104,0,1,0,232,128,104.11,104.11,0,0,0,128,24Zm0,192a88,88,0,1,1,88-88A88.1,88.1,0,0,1,128,216Zm48-88a8,8,0,0,1-8,8H136v32a8,8,0,0,1-16,0V136H88a8,8,0,0,1,0-16h32V88a8,8,0,0,1,16,0v32h32A8,8,0,0,1,176,128Z'></path>
-            </svg>
-          </button>
-        </header>
-        <div className='flex flex-col justify-center gap-y-4 items-center place-items-center h-[600px] w-full text-zinc-700 dark:text-zinc-300'>
+    <section>
+      <header className='flex w-full justify-between'>
+        <h1 className='text-2xl text-zinc-900 dark:text-zinc-200 mb-3 font-semibold'>
+          Home
+        </h1>
+        <button className='inline-flex items-center rounded-full bg-fuchsia-600 px-8 py-3 text-sm font-semibold text-white gap-x-1 focus:outline-none focus:ring active:bg-indigo-500'>
+          <span>Create new link</span>
           <svg
             xmlns='http://www.w3.org/2000/svg'
-            width='200'
-            height='200'
+            width='24'
+            height='24'
             fill='currentColor'
             viewBox='0 0 256 256'
           >
-            <path d='M128,24A104,104,0,1,0,232,128,104.11,104.11,0,0,0,128,24Zm0,16a87.5,87.5,0,0,1,48,14.28V74L153.83,99.74,122.36,104l-.31-.22L102.38,90.92A16,16,0,0,0,79.87,95.1L58.93,126.4a16,16,0,0,0-2.7,8.81L56,171.44l-3.27,2.15A88,88,0,0,1,128,40ZM62.29,186.47l2.52-1.65A16,16,0,0,0,72,171.53l.21-36.23L93.17,104a3.62,3.62,0,0,0,.32.22l19.67,12.87a15.94,15.94,0,0,0,11.35,2.77L156,115.59a16,16,0,0,0,10-5.41l22.17-25.76A16,16,0,0,0,192,74V67.67A87.87,87.87,0,0,1,211.77,155l-16.14-14.76a16,16,0,0,0-16.93-3l-30.46,12.65a16.08,16.08,0,0,0-9.68,12.45l-2.39,16.19a16,16,0,0,0,11.77,17.81L169.4,202l2.36,2.37A87.88,87.88,0,0,1,62.29,186.47ZM185,195l-4.3-4.31a16,16,0,0,0-7.26-4.18L152,180.85l2.39-16.19L184.84,152,205,170.48A88.43,88.43,0,0,1,185,195Z'></path>
+            <path d='M128,24A104,104,0,1,0,232,128,104.11,104.11,0,0,0,128,24Zm0,192a88,88,0,1,1,88-88A88.1,88.1,0,0,1,128,216Zm48-88a8,8,0,0,1-8,8H136v32a8,8,0,0,1-16,0V136H88a8,8,0,0,1,0-16h32V88a8,8,0,0,1,16,0v32h32A8,8,0,0,1,176,128Z'></path>
           </svg>
-          <p className='text-sm md:text-base'>No links yet</p>
-          <button className='inline-flex items-center rounded-full bg-fuchsia-600 px-8 py-3 transition hover:rotate-6 text-sm font-semibold text-white gap-x-1 focus:outline-none focus:ring active:bg-indigo-500 mt-4'>
-            <span>Create new link</span>
-            <svg
-              xmlns='http://www.w3.org/2000/svg'
-              width='24'
-              height='24'
-              fill='currentColor'
-              viewBox='0 0 256 256'
-            >
-              <path d='M128,24A104,104,0,1,0,232,128,104.11,104.11,0,0,0,128,24Zm0,192a88,88,0,1,1,88-88A88.1,88.1,0,0,1,128,216Zm48-88a8,8,0,0,1-8,8H136v32a8,8,0,0,1-16,0V136H88a8,8,0,0,1,0-16h32V88a8,8,0,0,1,16,0v32h32A8,8,0,0,1,176,128Z'></path>
-            </svg>
-          </button>
-        </div>
-      </section>
-    </DashboardLayout>
+        </button>
+      </header>
+      <div className='flex flex-col justify-center gap-y-4 items-center place-items-center h-[600px] w-full text-zinc-700 dark:text-zinc-300'>
+        <svg
+          xmlns='http://www.w3.org/2000/svg'
+          width='200'
+          height='200'
+          fill='currentColor'
+          viewBox='0 0 256 256'
+        >
+          <path d='M128,24A104,104,0,1,0,232,128,104.11,104.11,0,0,0,128,24Zm0,16a87.5,87.5,0,0,1,48,14.28V74L153.83,99.74,122.36,104l-.31-.22L102.38,90.92A16,16,0,0,0,79.87,95.1L58.93,126.4a16,16,0,0,0-2.7,8.81L56,171.44l-3.27,2.15A88,88,0,0,1,128,40ZM62.29,186.47l2.52-1.65A16,16,0,0,0,72,171.53l.21-36.23L93.17,104a3.62,3.62,0,0,0,.32.22l19.67,12.87a15.94,15.94,0,0,0,11.35,2.77L156,115.59a16,16,0,0,0,10-5.41l22.17-25.76A16,16,0,0,0,192,74V67.67A87.87,87.87,0,0,1,211.77,155l-16.14-14.76a16,16,0,0,0-16.93-3l-30.46,12.65a16.08,16.08,0,0,0-9.68,12.45l-2.39,16.19a16,16,0,0,0,11.77,17.81L169.4,202l2.36,2.37A87.88,87.88,0,0,1,62.29,186.47ZM185,195l-4.3-4.31a16,16,0,0,0-7.26-4.18L152,180.85l2.39-16.19L184.84,152,205,170.48A88.43,88.43,0,0,1,185,195Z'></path>
+        </svg>
+        <p className='text-sm md:text-base'>No links yet</p>
+        <button className='inline-flex items-center rounded-full bg-fuchsia-600 px-8 py-3 transition hover:rotate-6 text-sm font-semibold text-white gap-x-1 focus:outline-none focus:ring active:bg-indigo-500 mt-4'>
+          <span>Create new link</span>
+          <svg
+            xmlns='http://www.w3.org/2000/svg'
+            width='24'
+            height='24'
+            fill='currentColor'
+            viewBox='0 0 256 256'
+          >
+            <path d='M128,24A104,104,0,1,0,232,128,104.11,104.11,0,0,0,128,24Zm0,192a88,88,0,1,1,88-88A88.1,88.1,0,0,1,128,216Zm48-88a8,8,0,0,1-8,8H136v32a8,8,0,0,1-16,0V136H88a8,8,0,0,1,0-16h32V88a8,8,0,0,1,16,0v32h32A8,8,0,0,1,176,128Z'></path>
+          </svg>
+        </button>
+      </div>
+    </section>
   );
 }

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,5 +1,6 @@
 import { PlusJakartaSans } from "@/lib/font";
 import Provider from "@/providers/ThemeProvider";
+import { Toaster } from "@/components/ui/sonner";
 import "@/styles/globals.css";
 import type { Metadata } from "next";
 
@@ -16,7 +17,10 @@ export default function RootLayout({
   return (
     <html lang='en' suppressHydrationWarning>
       <body style={PlusJakartaSans.style}>
-        <Provider>{children}</Provider>
+        <Provider>
+          <Toaster position='top-right' richColors />
+          {children}
+        </Provider>
       </body>
     </html>
   );

--- a/frontend/app/onboarding/page.tsx
+++ b/frontend/app/onboarding/page.tsx
@@ -1,0 +1,59 @@
+"use client";
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { useOnboarding } from "@/hooks/useOnboarding";
+import { getProjectsAction } from "@/app/actions/project";
+import PersonalDetailsStep from "@/components/onboarding/PersonalDetailsStep";
+import NewProjectStep from "@/components/onboarding/NewProjectStep";
+
+export default function OnboardingPage() {
+  const router = useRouter();
+  const { step, setStep, isLoading, submitProfile, submitProject } =
+    useOnboarding();
+
+  // If user already has a project, send them to the dashboard
+  useEffect(() => {
+    getProjectsAction()
+      .then((projects) => {
+        if (Array.isArray(projects) && projects.length > 0) {
+          router.replace("/dashboard");
+        }
+      })
+      .catch(() => {});
+  }, [router]);
+
+  return (
+    <main className="min-h-screen bg-gradient-to-br from-zinc-950 to-zinc-900 flex flex-col items-center justify-center px-4">
+      <div className="mb-8 text-2xl font-bold text-white tracking-tight">
+        spit<span className="text-fuchsia-500">.sh</span>
+      </div>
+
+      <div className="w-full max-w-md bg-zinc-900 border border-zinc-800 rounded-2xl shadow-2xl p-8">
+        {/* Step dots */}
+        <div className="flex gap-2 justify-center mb-8">
+          <span
+            className={`h-2 w-6 rounded-full transition-all ${
+              step === 1 ? "bg-fuchsia-500" : "bg-zinc-700"
+            }`}
+          />
+          <span
+            className={`h-2 w-6 rounded-full transition-all ${
+              step === 2 ? "bg-fuchsia-500" : "bg-zinc-700"
+            }`}
+          />
+        </div>
+
+        {step === 1 && (
+          <PersonalDetailsStep onSubmit={submitProfile} isLoading={isLoading} />
+        )}
+        {step === 2 && (
+          <NewProjectStep
+            onSubmit={submitProject}
+            onBack={() => setStep(1)}
+            isLoading={isLoading}
+          />
+        )}
+      </div>
+    </main>
+  );
+}

--- a/frontend/components/DashboardHomeNavbar.tsx
+++ b/frontend/components/DashboardHomeNavbar.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import Image from "next/image";
+import Link from "next/link";
+import { useState, useRef, useEffect } from "react";
+import { useSession, signOut } from "@/lib/auth-client";
+import { deleteUserCookie } from "@/app/actions/auth";
+
+export default function DashboardHomeNavbar() {
+  const { data: session } = useSession();
+  const [open, setOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, []);
+
+  const handleLogout = async () => {
+    await Promise.all([signOut(), deleteUserCookie()]);
+    window.location.href = "/signin";
+  };
+
+  const avatarSrc =
+    session?.user.image ??
+    `https://api.dicebear.com/9.x/fun-emoji/svg?seed=${encodeURIComponent(
+      session?.user.email ?? "user"
+    )}`;
+
+  return (
+    <header className="flex items-center justify-between px-8 py-4 border-b border-zinc-800">
+      <Link href="/dashboard" className="font-bold text-2xl tracking-tight text-white">
+        Spit<span className="text-fuchsia-500">.sh</span>
+      </Link>
+
+      <div className="relative" ref={dropdownRef}>
+        <button
+          onClick={() => setOpen((v) => !v)}
+          className="flex items-center gap-3 hover:opacity-80 transition-opacity"
+        >
+          <Image
+            alt={session?.user.name ?? "User"}
+            src={avatarSrc}
+            className="rounded-full object-cover"
+            height={36}
+            width={36}
+            unoptimized
+          />
+          <div className="hidden sm:block text-left">
+            <p className="text-sm font-medium leading-none">
+              {session?.user.name ?? session?.user.email ?? "—"}
+            </p>
+            <p className="text-xs text-zinc-400 mt-0.5">{session?.user.email}</p>
+          </div>
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            className={`h-4 w-4 text-zinc-400 transition-transform ${open ? "rotate-180" : ""}`}
+            viewBox="0 0 20 20"
+            fill="currentColor"
+          >
+            <path
+              fillRule="evenodd"
+              d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z"
+              clipRule="evenodd"
+            />
+          </svg>
+        </button>
+
+        {open && (
+          <div className="absolute right-0 mt-2 w-44 bg-zinc-900 border border-zinc-700 rounded-lg shadow-xl z-50 overflow-hidden">
+            <button
+              onClick={handleLogout}
+              className="w-full px-4 py-2.5 text-sm text-left text-zinc-300 hover:bg-zinc-800 transition-colors"
+            >
+              Log out
+            </button>
+          </div>
+        )}
+      </div>
+    </header>
+  );
+}

--- a/frontend/components/icons/ArrowRight.tsx
+++ b/frontend/components/icons/ArrowRight.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+
+const ArrowRight = ({
+  className,
+  size = 32,
+}: {
+  className?: string;
+  size?: number;
+}) => {
+  return (
+    <svg
+      xmlns='http://www.w3.org/2000/svg'
+      width={size}
+      height={size}
+      fill='currentColor'
+      viewBox='0 0 256 256'
+    >
+      <path d='M128,20A108,108,0,1,0,236,128,108.12,108.12,0,0,0,128,20ZM79.57,196.57a60,60,0,0,1,96.86,0,83.72,83.72,0,0,1-96.86,0ZM100,120a28,28,0,1,1,28,28A28,28,0,0,1,100,120ZM194,179.94a83.48,83.48,0,0,0-29-23.42,52,52,0,1,0-74,0,83.48,83.48,0,0,0-29,23.42,84,84,0,1,1,131.9,0Z'></path>
+    </svg>
+  );
+};
+
+export default ArrowRight;

--- a/frontend/components/icons/FolderIcon.tsx
+++ b/frontend/components/icons/FolderIcon.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+
+const FolderIcon = ({
+  size = 32,
+  className,
+}: {
+  className?: string;
+  size?: number;
+}) => {
+  return (
+    <svg
+      xmlns='http://www.w3.org/2000/svg'
+      width={size}
+      height={size}
+      fill='currentColor'
+      viewBox='0 0 256 256'
+      className={className}
+    >
+      <path
+        d='M128,80H32V56a8,8,0,0,1,8-8H92.69a8,8,0,0,1,5.65,2.34Z'
+        opacity='0.2'
+      ></path>
+      <path d='M216,72H131.31L104,44.69A15.86,15.86,0,0,0,92.69,40H40A16,16,0,0,0,24,56V200.62A15.4,15.4,0,0,0,39.38,216H216.89A15.13,15.13,0,0,0,232,200.89V88A16,16,0,0,0,216,72ZM92.69,56l16,16H40V56ZM216,200H40V88H216Z'></path>
+    </svg>
+  );
+};
+
+export default FolderIcon;

--- a/frontend/components/icons/ImageSquareIcon.tsx
+++ b/frontend/components/icons/ImageSquareIcon.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+
+const ImageSquareIcon = ({
+  size = 32,
+  className,
+}: {
+  size?: number;
+  className?: string;
+}) => {
+  return (
+    <svg
+      xmlns='http://www.w3.org/2000/svg'
+      width={size}
+      height={size}
+      fill='#000000'
+      viewBox='0 0 256 256'
+      className={className}
+    >
+      <path d='M208,32H80A16,16,0,0,0,64,48V64H48A16,16,0,0,0,32,80V208a16,16,0,0,0,16,16H176a16,16,0,0,0,16-16V192h16a16,16,0,0,0,16-16V48A16,16,0,0,0,208,32ZM80,48H208v69.38l-16.7-16.7a16,16,0,0,0-22.62,0L93.37,176H80Zm96,160H48V80H64v96a16,16,0,0,0,16,16h96Zm32-32H116l64-64,28,28v36Zm-88-64A24,24,0,1,0,96,88,24,24,0,0,0,120,112Zm0-32a8,8,0,1,1-8,8A8,8,0,0,1,120,80Z'></path>
+    </svg>
+  );
+};
+
+export default ImageSquareIcon;

--- a/frontend/components/icons/ImageSquareIcon.tsx
+++ b/frontend/components/icons/ImageSquareIcon.tsx
@@ -12,7 +12,7 @@ const ImageSquareIcon = ({
       xmlns='http://www.w3.org/2000/svg'
       width={size}
       height={size}
-      fill='#000000'
+      fill='currentColor'
       viewBox='0 0 256 256'
       className={className}
     >

--- a/frontend/components/icons/PencilIcon.tsx
+++ b/frontend/components/icons/PencilIcon.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+
+const PencilIcon = ({
+  size = 32,
+  className,
+}: {
+  size?: number;
+  className?: string;
+}) => {
+  return (
+    <svg
+      xmlns='http://www.w3.org/2000/svg'
+      width={size}
+      height={size}
+      fill='currentColor'
+      viewBox='0 0 256 256'
+      className={className}
+    >
+      <path d='M227.31,73.37,182.63,28.68a16,16,0,0,0-22.63,0L36.69,152A15.86,15.86,0,0,0,32,163.31V208a16,16,0,0,0,16,16H92.69A15.86,15.86,0,0,0,104,219.31L227.31,96a16,16,0,0,0,0-22.63ZM92.69,208H48V163.31l88-88L180.69,120ZM192,108.68,147.31,64l24-24L216,84.68Z'></path>
+    </svg>
+  );
+};
+
+export default PencilIcon;

--- a/frontend/components/icons/UserCircle.tsx
+++ b/frontend/components/icons/UserCircle.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+
+const UserCircle = ({
+  className,
+  size = 32,
+}: {
+  className?: string;
+  size?: number;
+}) => {
+  return (
+    <svg
+      xmlns='http://www.w3.org/2000/svg'
+      width={size}
+      height={size}
+      fill='currentColor'
+      viewBox='0 0 256 256'
+      className={className}
+    >
+      <path
+        d='M224,128a95.76,95.76,0,0,1-31.8,71.37A72,72,0,0,0,128,160a40,40,0,1,0-40-40,40,40,0,0,0,40,40,72,72,0,0,0-64.2,39.37h0A96,96,0,1,1,224,128Z'
+        opacity='0.2'
+      ></path>
+      <path d='M128,24A104,104,0,1,0,232,128,104.11,104.11,0,0,0,128,24ZM74.08,197.5a64,64,0,0,1,107.84,0,87.83,87.83,0,0,1-107.84,0ZM96,120a32,32,0,1,1,32,32A32,32,0,0,1,96,120Zm97.76,66.41a79.66,79.66,0,0,0-36.06-28.75,48,48,0,1,0-59.4,0,79.66,79.66,0,0,0-36.06,28.75,88,88,0,1,1,131.52,0Z'></path>
+    </svg>
+  );
+};
+
+export default UserCircle;

--- a/frontend/components/onboarding/NewProjectStep.tsx
+++ b/frontend/components/onboarding/NewProjectStep.tsx
@@ -1,0 +1,189 @@
+"use client";
+import { useState } from "react";
+import { useFormik } from "formik";
+import * as Yup from "yup";
+import FolderIcon from "../icons/FolderIcon";
+import PencilIcon from "../icons/PencilIcon";
+import ImageSquareIcon from "../icons/ImageSquareIcon";
+import ArrowRight from "../icons/ArrowRight";
+
+interface Props {
+  onSubmit: (values: {
+    name: string;
+    slug: string;
+    logo?: string;
+  }) => Promise<void>;
+  onBack: () => void;
+  isLoading: boolean;
+}
+
+const slugify = (value: string) =>
+  value
+    .toLowerCase()
+    .replace(/\s+/g, "-")
+    .replace(/[^a-z0-9-]/g, "")
+    .slice(0, 30);
+
+const validationSchema = Yup.object({
+  name: Yup.string()
+    .required("Project name is required")
+    .max(20, "Max 20 characters"),
+  slug: Yup.string()
+    .required("Slug is required")
+    .max(30, "Max 30 characters")
+    .matches(/^[a-z0-9-]+$/, "Only lowercase letters, numbers, and hyphens"),
+  logo: Yup.string().url("Must be a valid URL").optional(),
+});
+
+export default function NewProjectStep({ onSubmit, onBack, isLoading }: Props) {
+  const [slugEdited, setSlugEdited] = useState(false);
+  const [slugLocked, setSlugLocked] = useState(true);
+
+  const formik = useFormik({
+    initialValues: { name: "", slug: "", logo: "" },
+    validationSchema,
+    onSubmit: ({ name, slug, logo }) =>
+      onSubmit({ name, slug, logo: logo || undefined }),
+  });
+
+  const handleNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    formik.handleChange(e);
+    if (!slugEdited) {
+      formik.setFieldValue("slug", slugify(e.target.value));
+    }
+  };
+
+  const handleSlugChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setSlugEdited(true);
+    formik.handleChange(e);
+  };
+
+  const isValidUrl = (val: string) => {
+    try {
+      new URL(val);
+      return true;
+    } catch {
+      return false;
+    }
+  };
+
+  return (
+    <div>
+      <FolderIcon size={56} className='text-fuchsia-500 mx-auto mb-4' />
+      <h1 className='text-xl font-bold text-white text-center mb-1'>
+        Create your first project
+      </h1>
+      <p className='text-sm text-zinc-400 text-center mb-8'>
+        Projects help you organise and share links.
+      </p>
+
+      <form onSubmit={formik.handleSubmit} className='flex flex-col gap-5'>
+        {/* Project Name */}
+        <div>
+          <label className='block text-xs font-medium text-zinc-400 mb-1.5'>
+            Project Name
+          </label>
+          <input
+            name='name'
+            value={formik.values.name}
+            onChange={handleNameChange}
+            onBlur={formik.handleBlur}
+            placeholder='My Workspace'
+            className='w-full rounded-xl border border-zinc-700 bg-transparent px-4 py-3 text-sm text-white placeholder:text-zinc-600 focus:outline-none focus:ring-2 focus:ring-fuchsia-500'
+          />
+          {formik.touched.name && formik.errors.name && (
+            <p className='text-red-400 text-xs mt-1'>{formik.errors.name}</p>
+          )}
+        </div>
+
+        {/* Slug */}
+        <div>
+          <label className='block text-xs font-medium text-zinc-400 mb-1.5'>
+            Slug
+          </label>
+          <div className='flex items-center rounded-xl border border-zinc-700 focus-within:ring-2 focus-within:ring-fuchsia-500 overflow-hidden'>
+            <span className='px-3 text-sm text-zinc-500 select-none whitespace-nowrap'>
+              spit.sh/
+            </span>
+            <input
+              name='slug'
+              value={formik.values.slug}
+              onChange={handleSlugChange}
+              onBlur={formik.handleBlur}
+              disabled={slugLocked}
+              placeholder='my-workspace'
+              className='flex-1 bg-transparent py-3 pr-3 text-sm text-white placeholder:text-zinc-600 focus:outline-none disabled:text-zinc-500'
+            />
+            <button
+              type='button'
+              onClick={() => setSlugLocked((prev) => !prev)}
+              className='px-3 text-zinc-500 hover:text-fuchsia-400 transition-colors'
+              title={slugLocked ? "Edit slug" : "Lock slug"}
+            >
+              <PencilIcon
+                size={16}
+                className={slugLocked ? "" : "text-fuchsia-400"}
+              />
+            </button>
+          </div>
+          {formik.touched.slug && formik.errors.slug && (
+            <p className='text-red-400 text-xs mt-1'>{formik.errors.slug}</p>
+          )}
+        </div>
+
+        {/* Logo URL */}
+        <div>
+          <label className='block text-xs font-medium text-zinc-400 mb-1.5'>
+            Logo URL{" "}
+            <span className='text-zinc-600 font-normal'>(optional)</span>
+          </label>
+          <div className='flex items-center gap-3'>
+            <div className='relative flex-1'>
+              <ImageSquareIcon
+                size={16}
+                className='absolute left-3 top-1/2 -translate-y-1/2 text-zinc-500'
+              />
+              <input
+                name='logo'
+                value={formik.values.logo}
+                onChange={formik.handleChange}
+                onBlur={formik.handleBlur}
+                placeholder='https://example.com/logo.png'
+                className='w-full rounded-xl border border-zinc-700 bg-transparent pl-9 pr-4 py-3 text-sm text-white placeholder:text-zinc-600 focus:outline-none focus:ring-2 focus:ring-fuchsia-500'
+              />
+            </div>
+            {formik.values.logo && isValidUrl(formik.values.logo) ? (
+              <img
+                src={formik.values.logo}
+                alt='logo preview'
+                className='w-9 h-9 rounded-full object-cover border border-zinc-700 shrink-0'
+              />
+            ) : (
+              <div className='w-9 h-9 rounded-full border border-zinc-700 bg-zinc-800 shrink-0' />
+            )}
+          </div>
+          {formik.touched.logo && formik.errors.logo && (
+            <p className='text-red-400 text-xs mt-1'>{formik.errors.logo}</p>
+          )}
+        </div>
+
+        <button
+          type='submit'
+          disabled={isLoading}
+          className='mt-2 w-full flex items-center justify-center gap-2 bg-fuchsia-600 text-white px-8 py-3 rounded-full font-semibold hover:bg-fuchsia-700 focus:outline-none focus:ring focus:ring-offset-2 focus:ring-fuchsia-200 transition-all disabled:opacity-60 disabled:cursor-not-allowed'
+        >
+          {isLoading ? "Creating…" : "Create Project"}
+          {!isLoading && <ArrowRight />}
+        </button>
+
+        <button
+          type='button'
+          onClick={onBack}
+          className='text-sm text-zinc-400 hover:text-zinc-200 transition-colors text-center'
+        >
+          ← Back
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/frontend/components/onboarding/PersonalDetailsStep.tsx
+++ b/frontend/components/onboarding/PersonalDetailsStep.tsx
@@ -3,6 +3,8 @@ import { useFormik } from "formik";
 import * as Yup from "yup";
 import UserCircle from "../icons/UserCircle";
 import ArrowRight from "../icons/ArrowRight";
+import { useSession } from "@/lib/auth-client";
+import { useEffect } from "react";
 
 interface Props {
   onSubmit: (values: {
@@ -22,11 +24,24 @@ const validationSchema = Yup.object({
 });
 
 export default function PersonalDetailsStep({ onSubmit, isLoading }: Props) {
+  const { data: session } = useSession();
+  const name = session?.user?.name || "";
+  const [first_name, last_name] = name.split(" ");
   const formik = useFormik({
-    initialValues: { first_name: "", last_name: "" },
+    initialValues: { first_name: first_name || "", last_name: last_name || "" },
     validationSchema,
     onSubmit,
   });
+
+  useEffect(() => {
+    if (session?.user?.name) {
+      const [first_name, last_name] = session.user.name.split(" ");
+      formik.setValues({
+        first_name: first_name || "",
+        last_name: last_name || "",
+      });
+    } // Run this effect whenever the session user name changes
+  }, [session?.user?.name]); // Run this effect whenever the session user name changes
 
   return (
     <div>

--- a/frontend/components/onboarding/PersonalDetailsStep.tsx
+++ b/frontend/components/onboarding/PersonalDetailsStep.tsx
@@ -1,0 +1,91 @@
+"use client";
+import { useFormik } from "formik";
+import * as Yup from "yup";
+import UserCircle from "../icons/UserCircle";
+import ArrowRight from "../icons/ArrowRight";
+
+interface Props {
+  onSubmit: (values: {
+    first_name: string;
+    last_name: string;
+  }) => Promise<void>;
+  isLoading: boolean;
+}
+
+const validationSchema = Yup.object({
+  first_name: Yup.string()
+    .required("First name is required")
+    .max(20, "Max 20 characters"),
+  last_name: Yup.string()
+    .required("Last name is required")
+    .max(25, "Max 25 characters"),
+});
+
+export default function PersonalDetailsStep({ onSubmit, isLoading }: Props) {
+  const formik = useFormik({
+    initialValues: { first_name: "", last_name: "" },
+    validationSchema,
+    onSubmit,
+  });
+
+  return (
+    <div>
+      <UserCircle size={56} className='text-fuchsia-500 mx-auto mb-4' />
+      <h1 className='text-xl font-bold text-white text-center mb-1'>
+        Welcome to Spit.sh
+      </h1>
+      <p className='text-sm text-zinc-400 text-center mb-8'>
+        Let&apos;s set up your profile first.
+      </p>
+
+      <form onSubmit={formik.handleSubmit} className='flex flex-col gap-5'>
+        <div>
+          <label className='block text-xs font-medium text-zinc-400 mb-1.5'>
+            First Name
+          </label>
+          <input
+            name='first_name'
+            value={formik.values.first_name}
+            onChange={formik.handleChange}
+            onBlur={formik.handleBlur}
+            placeholder='Ada'
+            className='w-full rounded-xl border border-zinc-700 bg-transparent px-4 py-3 text-sm text-white placeholder:text-zinc-600 focus:outline-none focus:ring-2 focus:ring-fuchsia-500'
+          />
+          {formik.touched.first_name && formik.errors.first_name && (
+            <p className='text-red-400 text-xs mt-1'>
+              {formik.errors.first_name}
+            </p>
+          )}
+        </div>
+
+        <div>
+          <label className='block text-xs font-medium text-zinc-400 mb-1.5'>
+            Last Name
+          </label>
+          <input
+            name='last_name'
+            value={formik.values.last_name}
+            onChange={formik.handleChange}
+            onBlur={formik.handleBlur}
+            placeholder='Lovelace'
+            className='w-full rounded-xl border border-zinc-700 bg-transparent px-4 py-3 text-sm text-white placeholder:text-zinc-600 focus:outline-none focus:ring-2 focus:ring-fuchsia-500'
+          />
+          {formik.touched.last_name && formik.errors.last_name && (
+            <p className='text-red-400 text-xs mt-1'>
+              {formik.errors.last_name}
+            </p>
+          )}
+        </div>
+
+        <button
+          type='submit'
+          disabled={isLoading}
+          className='mt-2 w-full flex items-center justify-center gap-2 bg-fuchsia-600 text-white px-8 py-3 rounded-full font-semibold hover:bg-fuchsia-700 focus:outline-none focus:ring focus:ring-offset-2 focus:ring-fuchsia-200 transition-all disabled:opacity-60 disabled:cursor-not-allowed'
+        >
+          {isLoading ? "Saving…" : "Continue"}
+          {!isLoading && <ArrowRight />}
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/frontend/components/ui/sonner.tsx
+++ b/frontend/components/ui/sonner.tsx
@@ -1,3 +1,4 @@
+"use client";
 import {
   CheckCircle,
   Info,

--- a/frontend/components/ui/sonner.tsx
+++ b/frontend/components/ui/sonner.tsx
@@ -1,0 +1,40 @@
+import {
+  CheckCircle,
+  Info,
+  LoaderIcon,
+  XOctagon,
+  AlertTriangle,
+} from "lucide-react";
+import { Toaster as Sonner } from "sonner";
+
+type ToasterProps = React.ComponentProps<typeof Sonner>;
+
+const Toaster = ({ ...props }: ToasterProps) => {
+  return (
+    <Sonner
+      className='toaster group'
+      icons={{
+        success: <CheckCircle className='h-4 w-4' />,
+        info: <Info className='h-4 w-4' />,
+        warning: <AlertTriangle className='h-4 w-4' />,
+        error: <XOctagon className='h-4 w-4' />,
+        loading: <LoaderIcon className='h-4 w-4 animate-spin' />,
+      }}
+      toastOptions={{
+        classNames: {
+          toast:
+            "group toast group-[.toaster]:bg-oklch(1 0 0) group-[.toaster]:text-oklch(0.141 0.005 285.823) group-[.toaster]:border-oklch(0.92 0.004 286.32) group-[.toaster]:shadow-lg dark:group-[.toaster]:bg-oklch(0.141 0.005 285.823) dark:group-[.toaster]:text-oklch(0.985 0 0) dark:group-[.toaster]:border-oklch(1 0 0 / 10%)",
+          description:
+            "group-[.toast]:text-oklch(0.552 0.016 285.938) dark:group-[.toast]:text-oklch(0.705 0.015 286.067)",
+          actionButton:
+            "group-[.toast]:bg-oklch(0.21 0.006 285.885) group-[.toast]:text-oklch(0.985 0 0) dark:group-[.toast]:bg-oklch(0.92 0.004 286.32) dark:group-[.toast]:text-oklch(0.21 0.006 285.885)",
+          cancelButton:
+            "group-[.toast]:bg-oklch(0.967 0.001 286.375) group-[.toast]:text-oklch(0.552 0.016 285.938) dark:group-[.toast]:bg-oklch(0.274 0.006 286.033) dark:group-[.toast]:text-oklch(0.705 0.015 286.067)",
+        },
+      }}
+      {...props}
+    />
+  );
+};
+
+export { Toaster };

--- a/frontend/hooks/useOnboarding.ts
+++ b/frontend/hooks/useOnboarding.ts
@@ -1,0 +1,55 @@
+"use client";
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { updateProfileAction } from "@/app/actions/user";
+import { createProjectAction } from "@/app/actions/project";
+import { useToast } from "@/hooks/useToast";
+
+export function useOnboarding() {
+  const [step, setStep] = useState<1 | 2>(1);
+  const [isLoading, setIsLoading] = useState(false);
+  const router = useRouter();
+  const { showToast } = useToast();
+
+  const submitProfile = async (values: {
+    first_name: string;
+    last_name: string;
+  }) => {
+    setIsLoading(true);
+    try {
+      await updateProfileAction(values);
+      showToast("Profile saved!", "success");
+      setStep(2);
+    } catch {
+      showToast("Something went wrong. Please try again.", "error");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const submitProject = async (values: {
+    name: string;
+    slug: string;
+    logo?: string;
+  }) => {
+    setIsLoading(true);
+    try {
+      await createProjectAction(values);
+      showToast("Project created!", "success");
+      router.push("/dashboard");
+    } catch (err: any) {
+      if (err?.response?.status === 409) {
+        showToast(
+          "That slug is already taken. Please choose another.",
+          "warning"
+        );
+      } else {
+        showToast("Something went wrong. Please try again.", "error");
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return { step, setStep, isLoading, submitProfile, submitProject };
+}

--- a/frontend/hooks/useToast.ts
+++ b/frontend/hooks/useToast.ts
@@ -1,0 +1,25 @@
+"use client";
+import { toast } from "sonner";
+
+type ToastState = "success" | "warning" | "error" | "neutral";
+
+export function useToast() {
+  const showToast = (message: string, state: ToastState = "neutral") => {
+    switch (state) {
+      case "success":
+        toast.success(message);
+        break;
+      case "warning":
+        toast.warning(message);
+        break;
+      case "error":
+        toast.error(message);
+        break;
+      case "neutral":
+      default:
+        toast(message);
+    }
+  };
+
+  return { showToast };
+}

--- a/frontend/layouts/DashboardLayout.tsx
+++ b/frontend/layouts/DashboardLayout.tsx
@@ -2,16 +2,10 @@
 
 import Image from "next/image";
 import Link from "next/link";
-import Head from "next/head";
 import React, { FC, PropsWithChildren } from "react";
-import { useRouter } from "next/navigation";
 import { useSession, signOut } from "@/lib/auth-client";
 
-const DashboardLayout: FC<PropsWithChildren<{ title: string }>> = ({
-  children,
-  title,
-}) => {
-  const router = useRouter();
+const DashboardLayout: FC<PropsWithChildren> = ({ children }) => {
   const { data: session } = useSession();
 
   const handleLogout = async () => {
@@ -21,9 +15,6 @@ const DashboardLayout: FC<PropsWithChildren<{ title: string }>> = ({
 
   return (
     <>
-      <Head>
-        <title>Spit.sh | Dashboard - {title}</title>
-      </Head>
       <main className='flex h-screen bg-zinc-100 dark:bg-zinc-900 text-zinc-900 dark:text-zinc-200 relative'>
         <aside className='absolute left-0 inset-y-0 -translate-x-96 md:translate-x-0 md:relative z-20 flex h-screen flex-col justify-between border-e bg-zinc-50 dark:bg-zinc-950 dark:border-zinc-700 w-72'>
           <div className='px-4 py-6'>
@@ -47,7 +38,7 @@ const DashboardLayout: FC<PropsWithChildren<{ title: string }>> = ({
               <li>
                 <details className='group [&_summary::-webkit-details-marker]:hidden'>
                   <summary className='flex cursor-pointer items-center justify-between rounded-lg px-4 py-2 text-gray-500 hover:bg-gray-100 hover:text-gray-700'>
-                    <span className='text-sm font-medium'> Teams </span>
+                    <span className='text-sm font-medium'> Links </span>
 
                     <span className='shrink-0 transition duration-300 group-open:-rotate-180'>
                       <svg
@@ -71,7 +62,7 @@ const DashboardLayout: FC<PropsWithChildren<{ title: string }>> = ({
                         href=''
                         className='block rounded-lg px-4 py-2 text-sm font-medium text-gray-500 hover:bg-gray-100 hover:text-gray-700'
                       >
-                        Banned Users
+                        All Links
                       </a>
                     </li>
 
@@ -184,16 +175,9 @@ const DashboardLayout: FC<PropsWithChildren<{ title: string }>> = ({
         </aside>
         <section className='flex-1 h-screen relative'>
           <nav className='py-5 px-6 border-b bg-zinc-50 dark:bg-zinc-950 dark:border-zinc-700 flex w-full justify-between items-center relative'>
-            <Link
-              href='/'
-              className='text-fuchsia-600 dark:text-fuchsia-500 font-bold inline-block text-xl'
-            >
-              Spit.sh ✨
-            </Link>
-            <p className='text-sm'>
-              <strong className='block font-medium'>
-                {session?.user.name ?? session?.user.email}
-              </strong>
+            <h1 className='text-lg font-semibold'>Dashboard</h1>
+            <p className='text-xs font-medium px-3 py-1.5 border border-fuchsia-200 dark:border-fuchsia-900 text-fuchsia-600 dark:text-fuchsia-400 bg-fuchsia-50 dark:bg-fuchsia-950/50 rounded-full'>
+              Currently in beta
             </p>
           </nav>
           <main className='p-6 md:px-10 relative'>

--- a/frontend/layouts/DashboardLayout.tsx
+++ b/frontend/layouts/DashboardLayout.tsx
@@ -4,12 +4,13 @@ import Image from "next/image";
 import Link from "next/link";
 import React, { FC, PropsWithChildren } from "react";
 import { useSession, signOut } from "@/lib/auth-client";
+import { deleteUserCookie } from "@/app/actions/auth";
 
 const DashboardLayout: FC<PropsWithChildren> = ({ children }) => {
   const { data: session } = useSession();
 
   const handleLogout = async () => {
-    await signOut();
+    await Promise.all([signOut(), deleteUserCookie()]);
     window.location.href = "/signin";
   };
 

--- a/frontend/lib/auth.ts
+++ b/frontend/lib/auth.ts
@@ -1,5 +1,5 @@
 import { betterAuth } from "better-auth";
-import { emailOTP } from "better-auth/plugins";
+import { emailOTP, bearer } from "better-auth/plugins";
 import { Pool } from "pg";
 import { Resend } from "resend";
 import {
@@ -25,6 +25,7 @@ export const auth = betterAuth({
   baseURL: BETTER_AUTH_URL,
   secret: BETTER_AUTH_SECRET,
   plugins: [
+    bearer(),
     emailOTP({
       async sendVerificationOTP({ email, otp }) {
         const { data, error } = await resend.emails.send({

--- a/frontend/lib/queries/project.ts
+++ b/frontend/lib/queries/project.ts
@@ -1,0 +1,20 @@
+import axios from "axios";
+import { API_URL } from "@/lib/config/public_env";
+
+export const createProject = async (
+  data: { name: string; slug: string; logo?: string },
+  token: string,
+) => {
+  const res = await axios.post(`${API_URL}/projects/`, data, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  return res.data;
+};
+
+export const getProjects = async (token: string) => {
+  console.log("Fetching projects with token:", token); // Debug log
+  const res = await axios.get(`${API_URL}/projects/`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  return res.data;
+};

--- a/frontend/lib/queries/project.ts
+++ b/frontend/lib/queries/project.ts
@@ -12,7 +12,6 @@ export const createProject = async (
 };
 
 export const getProjects = async (token: string) => {
-  console.log("Fetching projects with token:", token); // Debug log
   const res = await axios.get(`${API_URL}/projects/`, {
     headers: { Authorization: `Bearer ${token}` },
   });

--- a/frontend/lib/queries/user.ts
+++ b/frontend/lib/queries/user.ts
@@ -1,0 +1,19 @@
+import axios from "axios";
+import { API_URL } from "@/lib/config/public_env";
+
+export const getProfile = async (token: string) => {
+  const res = await axios.get(`${API_URL}/users/me`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  return res.data;
+};
+
+export const updateProfile = async (
+  data: { first_name: string; last_name: string; image?: string },
+  token: string
+) => {
+  const res = await axios.patch(`${API_URL}/users/me`, data, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  return res.data;
+};

--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -47,7 +47,7 @@ export async function middleware(request: NextRequest) {
   }
 
   // Redirect to dashboard if user is already signed in and tries to access sign-in or verify pages
-  if (slug.startsWith("signin") || slug.startsWith("verify")) {
+  if (slug.startsWith("signin") || slug.startsWith("verify") || slug.startsWith("callback")) {
     return NextResponse.next();
   }
 

--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -27,8 +27,8 @@ const getSessionCookie = (request: NextRequest) => {
 export async function middleware(request: NextRequest) {
   const slug = request.nextUrl.pathname.slice(1);
 
-  // Protect dashboard — redirect to sign-in if no session cookie
-  if (slug.startsWith("dashboard")) {
+  // Protect dashboard and onboarding — redirect to sign-in if no session cookie
+  if (slug.startsWith("dashboard") || slug.startsWith("onboarding")) {
     const sessionCookie = getSessionCookie(request);
     if (!sessionCookie) {
       return NextResponse.redirect(new URL("/signin", request.url));
@@ -48,10 +48,6 @@ export async function middleware(request: NextRequest) {
 
   // Redirect to dashboard if user is already signed in and tries to access sign-in or verify pages
   if (slug.startsWith("signin") || slug.startsWith("verify")) {
-    const sessionCookie = getSessionCookie(request);
-    if (sessionCookie) {
-      return NextResponse.redirect(new URL("/dashboard", request.url));
-    }
     return NextResponse.next();
   }
 

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -2,7 +2,7 @@
 const nextConfig = {
   reactStrictMode: true,
   images: {
-    domains: ["api.dicebear.com"],
+    domains: ["api.dicebear.com", "lh3.googleusercontent.com"],
   },
 };
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,6 +22,7 @@
     "eslint-config-next": "15.2.2",
     "formik": "^2.4.5",
     "input-otp": "^1.4.2",
+    "jose": "^6.2.1",
     "lucide-react": "^0.344.0",
     "next": "^14.1.0",
     "next-themes": "^0.3.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -31,6 +31,7 @@
     "react-dom": "^18.2.0",
     "resend": "^6.9.3",
     "shadcn-ui": "^0.8.0",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^2.2.1",
     "tailwindcss": "^3.4.1",
     "tailwindcss-animate": "^1.0.7",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -74,6 +74,9 @@ importers:
       shadcn-ui:
         specifier: ^0.8.0
         version: 0.8.0(typescript@5.9.3)
+      sonner:
+        specifier: ^2.0.7
+        version: 2.0.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       tailwind-merge:
         specifier: ^2.2.1
         version: 2.6.1
@@ -2970,6 +2973,12 @@ packages:
 
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
+
+  sonner@2.0.7:
+    resolution: {integrity: sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -6234,6 +6243,11 @@ snapshots:
   signal-exit@4.1.0: {}
 
   sisteransi@1.0.5: {}
+
+  sonner@2.0.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   source-map-js@1.2.1: {}
 

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       input-otp:
         specifier: ^1.4.2
         version: 1.4.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      jose:
+        specifier: ^6.2.1
+        version: 6.2.1
       lucide-react:
         specifier: ^0.344.0
         version: 0.344.0(react@18.3.1)
@@ -2187,8 +2190,8 @@ packages:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
 
-  jose@6.1.3:
-    resolution: {integrity: sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==}
+  jose@6.2.1:
+    resolution: {integrity: sha512-jUaKr1yrbfaImV7R2TN/b3IcZzsw38/chqMpo2XJ7i2F8AfM/lA4G1goC3JVEwg0H7UldTmSt3P68nt31W7/mw==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -3479,50 +3482,50 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
-  '@better-auth/core@1.5.2(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.1)':
+  '@better-auth/core@1.5.2(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.11)(nanostores@1.1.1)':
     dependencies:
       '@better-auth/utils': 0.3.1
       '@better-fetch/fetch': 1.1.21
       '@standard-schema/spec': 1.1.0
       better-call: 1.3.2(zod@4.3.6)
-      jose: 6.1.3
+      jose: 6.2.1
       kysely: 0.28.11
       nanostores: 1.1.1
       zod: 4.3.6
 
-  '@better-auth/drizzle-adapter@1.5.2(@better-auth/core@1.5.2(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(drizzle-orm@0.45.1(@electric-sql/pglite@0.3.15)(@prisma/client@7.4.2(prisma@7.4.2(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(typescript@5.9.3))(@types/pg@8.18.0)(kysely@0.28.11)(mysql2@3.15.3)(pg@8.19.0)(postgres@3.4.7)(prisma@7.4.2(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)))':
+  '@better-auth/drizzle-adapter@1.5.2(@better-auth/core@1.5.2(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(drizzle-orm@0.45.1(@electric-sql/pglite@0.3.15)(@prisma/client@7.4.2(prisma@7.4.2(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(typescript@5.9.3))(@types/pg@8.18.0)(kysely@0.28.11)(mysql2@3.15.3)(pg@8.19.0)(postgres@3.4.7)(prisma@7.4.2(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)))':
     dependencies:
-      '@better-auth/core': 1.5.2(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.1)
+      '@better-auth/core': 1.5.2(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.11)(nanostores@1.1.1)
       '@better-auth/utils': 0.3.1
       drizzle-orm: 0.45.1(@electric-sql/pglite@0.3.15)(@prisma/client@7.4.2(prisma@7.4.2(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(typescript@5.9.3))(@types/pg@8.18.0)(kysely@0.28.11)(mysql2@3.15.3)(pg@8.19.0)(postgres@3.4.7)(prisma@7.4.2(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))
 
-  '@better-auth/kysely-adapter@1.5.2(@better-auth/core@1.5.2(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(kysely@0.28.11)':
+  '@better-auth/kysely-adapter@1.5.2(@better-auth/core@1.5.2(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(kysely@0.28.11)':
     dependencies:
-      '@better-auth/core': 1.5.2(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.1)
+      '@better-auth/core': 1.5.2(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.11)(nanostores@1.1.1)
       '@better-auth/utils': 0.3.1
       kysely: 0.28.11
 
-  '@better-auth/memory-adapter@1.5.2(@better-auth/core@1.5.2(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)':
+  '@better-auth/memory-adapter@1.5.2(@better-auth/core@1.5.2(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)':
     dependencies:
-      '@better-auth/core': 1.5.2(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.1)
+      '@better-auth/core': 1.5.2(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.11)(nanostores@1.1.1)
       '@better-auth/utils': 0.3.1
 
-  '@better-auth/mongo-adapter@1.5.2(@better-auth/core@1.5.2(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(mongodb@7.1.0)':
+  '@better-auth/mongo-adapter@1.5.2(@better-auth/core@1.5.2(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(mongodb@7.1.0)':
     dependencies:
-      '@better-auth/core': 1.5.2(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.1)
+      '@better-auth/core': 1.5.2(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.11)(nanostores@1.1.1)
       '@better-auth/utils': 0.3.1
       mongodb: 7.1.0
 
-  '@better-auth/prisma-adapter@1.5.2(@better-auth/core@1.5.2(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(@prisma/client@7.4.2(prisma@7.4.2(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(typescript@5.9.3))(prisma@7.4.2(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))':
+  '@better-auth/prisma-adapter@1.5.2(@better-auth/core@1.5.2(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(@prisma/client@7.4.2(prisma@7.4.2(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(typescript@5.9.3))(prisma@7.4.2(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))':
     dependencies:
-      '@better-auth/core': 1.5.2(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.1)
+      '@better-auth/core': 1.5.2(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.11)(nanostores@1.1.1)
       '@better-auth/utils': 0.3.1
       '@prisma/client': 7.4.2(prisma@7.4.2(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(typescript@5.9.3)
       prisma: 7.4.2(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
 
-  '@better-auth/telemetry@1.5.2(@better-auth/core@1.5.2(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.1))':
+  '@better-auth/telemetry@1.5.2(@better-auth/core@1.5.2(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.11)(nanostores@1.1.1))':
     dependencies:
-      '@better-auth/core': 1.5.2(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.1)
+      '@better-auth/core': 1.5.2(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.11)(nanostores@1.1.1)
       '@better-auth/utils': 0.3.1
       '@better-fetch/fetch': 1.1.21
 
@@ -4417,20 +4420,20 @@ snapshots:
 
   better-auth@1.5.2(@prisma/client@7.4.2(prisma@7.4.2(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(typescript@5.9.3))(drizzle-orm@0.45.1(@electric-sql/pglite@0.3.15)(@prisma/client@7.4.2(prisma@7.4.2(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(typescript@5.9.3))(@types/pg@8.18.0)(kysely@0.28.11)(mysql2@3.15.3)(pg@8.19.0)(postgres@3.4.7)(prisma@7.4.2(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)))(mongodb@7.1.0)(mysql2@3.15.3)(next@14.2.35(@babel/core@7.29.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(pg@8.19.0)(prisma@7.4.2(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
-      '@better-auth/core': 1.5.2(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.1)
-      '@better-auth/drizzle-adapter': 1.5.2(@better-auth/core@1.5.2(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(drizzle-orm@0.45.1(@electric-sql/pglite@0.3.15)(@prisma/client@7.4.2(prisma@7.4.2(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(typescript@5.9.3))(@types/pg@8.18.0)(kysely@0.28.11)(mysql2@3.15.3)(pg@8.19.0)(postgres@3.4.7)(prisma@7.4.2(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)))
-      '@better-auth/kysely-adapter': 1.5.2(@better-auth/core@1.5.2(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(kysely@0.28.11)
-      '@better-auth/memory-adapter': 1.5.2(@better-auth/core@1.5.2(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)
-      '@better-auth/mongo-adapter': 1.5.2(@better-auth/core@1.5.2(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(mongodb@7.1.0)
-      '@better-auth/prisma-adapter': 1.5.2(@better-auth/core@1.5.2(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(@prisma/client@7.4.2(prisma@7.4.2(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(typescript@5.9.3))(prisma@7.4.2(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))
-      '@better-auth/telemetry': 1.5.2(@better-auth/core@1.5.2(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.1))
+      '@better-auth/core': 1.5.2(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.11)(nanostores@1.1.1)
+      '@better-auth/drizzle-adapter': 1.5.2(@better-auth/core@1.5.2(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(drizzle-orm@0.45.1(@electric-sql/pglite@0.3.15)(@prisma/client@7.4.2(prisma@7.4.2(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(typescript@5.9.3))(@types/pg@8.18.0)(kysely@0.28.11)(mysql2@3.15.3)(pg@8.19.0)(postgres@3.4.7)(prisma@7.4.2(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)))
+      '@better-auth/kysely-adapter': 1.5.2(@better-auth/core@1.5.2(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(kysely@0.28.11)
+      '@better-auth/memory-adapter': 1.5.2(@better-auth/core@1.5.2(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)
+      '@better-auth/mongo-adapter': 1.5.2(@better-auth/core@1.5.2(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(mongodb@7.1.0)
+      '@better-auth/prisma-adapter': 1.5.2(@better-auth/core@1.5.2(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(@prisma/client@7.4.2(prisma@7.4.2(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(typescript@5.9.3))(prisma@7.4.2(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))
+      '@better-auth/telemetry': 1.5.2(@better-auth/core@1.5.2(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.11)(nanostores@1.1.1))
       '@better-auth/utils': 0.3.1
       '@better-fetch/fetch': 1.1.21
       '@noble/ciphers': 2.1.1
       '@noble/hashes': 2.0.1
       better-call: 1.3.2(zod@4.3.6)
       defu: 6.1.4
-      jose: 6.1.3
+      jose: 6.2.1
       kysely: 0.28.11
       nanostores: 1.1.1
       zod: 4.3.6
@@ -5468,7 +5471,7 @@ snapshots:
 
   jiti@2.6.1: {}
 
-  jose@6.1.3: {}
+  jose@6.2.1: {}
 
   js-tokens@4.0.0: {}
 


### PR DESCRIPTION
- Replace opaque better-auth token with a signed HS256 JWT cookie
  (spit_session) for FastAPI authentication
- Set cookie on OTP verification (verify page) and OAuth callback
  (new /callback route handler)
- Dashboard home is now a server-side page that redirects based on
  project count: 0 → onboarding, 1 → workspace, 2+ → card grid
- Add DashboardHomeNavbar client component with user dropdown + logout
- Add 2-step onboarding flow: personal details + project creation
- Add server actions for all authenticated API calls (auth, project, user)
- Backend: add links_count to ProjectResponse via SQL COUNT JOIN
- Backend: add userRouter (GET/PATCH /users/me) and projectRouter
  (GET/POST /projects/) with JWT auth
- Add useToast hook wrapping sonner for typed toast notifications
- Add /callback route handler that reads the better-auth session post-OAuth, signs and sets the spit_session JWT cookie, then redirects to /dashboard.
- Update OAuth callbackURL from /dashboard to /callback and exclude /callback from middleware slug-redirect handling.
